### PR TITLE
Chore: Java 버전 21로 변경 및 .gitignore 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ replay_pid*
 # === Spring Boot 환경설정 파일 ===
 application.properties
 application-*.properties
+*.yml
 
 # === 기타 ===
 HELP.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-HELP.md
+# === Gradle ===
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-### STS ###
+# === STS / Eclipse ===
 .apt_generated
 .classpath
 .factorypath
@@ -17,7 +17,7 @@ bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 
-### IntelliJ IDEA ###
+# === IntelliJ IDEA ===
 .idea
 *.iws
 *.iml
@@ -26,12 +26,67 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 
-### NetBeans ###
+# === NetBeans ===
 /nbproject/private/
 /nbbuild/
 /dist/
 /nbdist/
 /.nb-gradle/
 
-### VS Code ###
+# === VSCode ===
 .vscode/
+
+# === OS 필요없는 파일 ===
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+*.icloud
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.stackdump
+[Dd]esktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+*.lnk
+
+# === Java ===
+*.class
+*.log
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+hs_err_pid*
+replay_pid*
+
+# === Spring Boot 환경설정 파일 ===
+application.properties
+application-*.properties
+
+# === 기타 ===
+HELP.md
+.env
+*.env

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=neogul-coder


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
없음

## 📌 과제 설명 
- `build.gradle`의 Java toolchain 버전을 17 → 21로 변경했습니다.
- `.gitignore`에 `application-*.properties`, IDE 및 OS 환경 파일 등을 추가하여 불필요한 커밋 방지 설정을 했습니다.

## 👩‍💻 요구 사항과 구현 내용 
- chore: Java 21로 설정 변경
- chore: .gitignore에 환경 설정 파일 및 빌드 산출물 정리

## ✅ PR 포인트 & 궁금한 점 
- 혹시 누락된 무시 파일이나 추가적으로 제외해야 할 파일이 있다면 피드백 부탁드립니다!
