### PR TITLE
feature: GCP + Docker 기반 배포 환경 구축

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM openjdk:21-ea-oraclelinux8
+
+# 타임존 설정
+RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone
+
+# JAR 복사
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
+
+# 앱 실행
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-ea-oraclelinux8
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,12 @@ java {
 	}
 }
 
+// 공통 버전 정의
+ext {
+	set('springCloudGcpVersion', "6.2.2")
+	set('springCloudVersion', "2024.0.1")
+}
+
 repositories {
 	mavenCentral()
 }
@@ -21,7 +27,7 @@ dependencies {
 	// 데이터 베이스 의존성
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 //	runtimeOnly 'com.h2database:h2'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+//	runtimeOnly 'org.postgresql:postgresql'
 
 	// Sql 쿼리 파라미터 보는 라이브러리
 //	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
@@ -55,8 +61,37 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// GCP 관련 의존성
+	implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager'
+	implementation 'com.google.cloud:google-cloud-storage'
+}
+
+dependencyManagement {
+	imports {
+		// Spring Cloud 전반 (Feign, Gateway 등) 의존성 버전 관리
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+		// GCP 관련 스타터(BOM) 관리 - Secret Manager, GCS 등
+		mavenBom "com.google.cloud:spring-cloud-gcp-dependencies:${springCloudGcpVersion}"
+	}
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// 환경별 application.properties 포함/제외 설정
+def activeProfile = project.hasProperty("profile") ? project.getProperty("profile") : "local"
+
+processResources {
+	filesMatching("**/application.properties") {
+		expand(profile: activeProfile)
+	}
+
+	// 환경에 따라 불필요한 설정 파일 제외
+	if (activeProfile == "local") {
+		exclude("application-prod.properties")
+	} else if (activeProfile == "prod") {
+		exclude("application-local.properties")
+	}
 }

--- a/src/main/java/grep/neogul_coder/NeogulCoderApplication.java
+++ b/src/main/java/grep/neogul_coder/NeogulCoderApplication.java
@@ -1,10 +1,17 @@
 package grep.neogul_coder;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class NeogulCoderApplication {
+
+	@PostConstruct
+	public void started(){
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(NeogulCoderApplication.class, args);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #3

## 📌 과제 설명
Spring Boot 애플리케이션을 GCP 환경에 배포하기 위해 Dockerfile을 작성하고, build.gradle에 GCP와 PostgreSQL 관련 의존성 추가 및 환경별 application 설정을 정비했습니다.  
또한, 애플리케이션 실행 시 JVM 타임존을 `Asia/Seoul`로 고정하도록 설정하였습니다.

## 👩‍💻 요구 사항과 구현 내용
- feat: Dockerfile 작성 (OpenJDK 기반 이미지, `app.jar` 실행)
- feat: 애플리케이션 시작 시 JVM 기본 타임존을 Asia/Seoul로 설정 (`@PostConstruct`)
- chore: build.gradle에 GCP 관련 의존성 및 버전 정의
- chore: MySQL → PostgreSQL로 DB 설정 전환 (driver, url, dialect 등)

## ✅ 피드백 반영사항
- 애플리케이션 전역 타임존 설정 필요 피드백 반영 (`Asia/Seoul`)

## ✅ PR 포인트 & 궁금한 점
- Dockerfile 및 배포 관련 GCP 설정이 올바르게 구성되었는지 확인 부탁드립니다.
- `@PostConstruct`를 활용한 타임존 설정 방식이 괜찮은지, 더 나은 위치/방법이 있다면 제안 부탁드립니다.
