### PR TITLE
[EA3-76] chore: 깃허브 이슈 라벨 매핑 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -42,7 +42,7 @@ body:
       description: '이슈의 성격에 맞는 라벨을 선택해주세요'
       multiple: false
       options:
-        - feat
+        - feature
         - fix
         - docs
         - style

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -54,7 +54,7 @@ jobs:
           LABEL="${{ steps.issue-parser.outputs.issueparser_label-selection }}"
           case "$LABEL" in
             fix) JIRA_ISSUETYPE="버그" ;;
-            feat|docs|style|refactor|test|chore) JIRA_ISSUETYPE="Task" ;;
+            feature|docs|style|refactor|test|chore) JIRA_ISSUETYPE="Task" ;;
             *) JIRA_ISSUETYPE="Task" ;;
           esac
           echo "JIRA_ISSUETYPE=$JIRA_ISSUETYPE" >> $GITHUB_ENV
@@ -87,7 +87,7 @@ jobs:
         run: |
           LABEL="${{ steps.issue-parser.outputs.issueparser_label-selection }}"
           case "$LABEL" in
-            feat) TYPE="Feature" ;;
+            feature) TYPE="Feature" ;;
             fix) TYPE="Fix" ;;
             docs) TYPE="Docs" ;;
             style) TYPE="Style" ;;
@@ -97,6 +97,21 @@ jobs:
             *) TYPE="$LABEL" ;;
           esac
           echo "TYPE=$TYPE" >> $GITHUB_ENV
+
+      - name: Map label to custom GitHub label
+        run: |
+          RAW_LABEL="${{ steps.issue-parser.outputs.issueparser_label-selection }}"
+          case "$RAW_LABEL" in
+            feature) CUSTOM_LABEL="✨ feature" ;;
+            fix) CUSTOM_LABEL="🐛 fix" ;;
+            docs) CUSTOM_LABEL="📝 docs" ;;
+            style) CUSTOM_LABEL="💄 style" ;;
+            refactor) CUSTOM_LABEL="♻️ refactor" ;;
+            test) CUSTOM_LABEL="🚨 test" ;;
+            chore) CUSTOM_LABEL="🔧 chore" ;;
+            *) CUSTOM_LABEL="$RAW_LABEL" ;;
+          esac
+          echo "CUSTOM_LABEL=$CUSTOM_LABEL" >> $GITHUB_ENV
 
       - name: Update issue title
         uses: actions-cool/issues-helper@v3
@@ -122,7 +137,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           labels: |
-            ${{ steps.issue-parser.outputs.issueparser_label-selection }}
+            ${{ env.CUSTOM_LABEL }}
 
       - name: Create branch with Epic number
         if: steps.issue-parser.outputs.issueparser_label-selection != 'fix'


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
해당 없음
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
GitHub 이슈 라벨 매핑을 변경하였습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- [EA3-76] chore: 깃허브 이슈 라벨 매핑 변경 – GitHub 이슈 생성 시 라벨 매핑 변경
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
이슈 템플릿이 잘 반영되는지 확인해주시면 감사하겠습니다.

[EA3-76]: https://hseric0816.atlassian.net/browse/EA3-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ