### PR TITLE
[EA3-100] chore: 인증 서버 배포를 위한 보안 및 빌드 설정 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,20 +21,23 @@ ext {
 
 repositories {
 	mavenCentral()
+	google()
 }
 
 dependencies {
 	// 데이터 베이스 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j:8.4.0'
+	//implementation 'com.h2database:h2:2.3.232'
+	//implementation 'org.springframework.boot:spring-boot-devtools'
 
 	// Sql 쿼리 파라미터 보는 라이브러리
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
-//	 테스트 데이터베이스 의존성
+    // 테스트 데이터베이스 의존성
 	testImplementation 'com.h2database:h2:1.4.200'
 
-	//Querydsl 추가
+	// Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
@@ -75,8 +78,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// GCP 관련 의존성
-//	implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager'
-//	implementation 'com.google.cloud:google-cloud-storage'
+	// implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager:4.9.1'
+	// implementation 'com.google.cloud:google-cloud-storage:2.38.0'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
@@ -85,9 +88,9 @@ dependencies {
 dependencyManagement {
 	imports {
 		// Spring Cloud 전반 (Feign, Gateway 등) 의존성 버전 관리
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+		// mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 		// GCP 관련 스타터(BOM) 관리 - Secret Manager, GCS 등
-		mavenBom "com.google.cloud:spring-cloud-gcp-dependencies:${springCloudGcpVersion}"
+		// mavenBom "com.google.cloud:spring-cloud-gcp-dependencies:${springCloudGcpVersion}"
 	}
 }
 
@@ -98,15 +101,15 @@ tasks.named('test') {
 // 환경별 application.properties 포함/제외 설정
 def activeProfile = project.hasProperty("profile") ? project.getProperty("profile") : "local"
 
-processResources {
-	filesMatching("**/application.properties") {
-		expand(profile: activeProfile)
-	}
-
-	// 환경에 따라 불필요한 설정 파일 제외
-	if (activeProfile == "local") {
-		exclude("application-prod.properties")
-	} else if (activeProfile == "prod") {
-		exclude("application-local.properties")
-	}
-}
+//processResources {
+//	filesMatching("**/application.properties") {
+//		expand(profile: activeProfile)
+//	}
+//
+//	// 환경에 따라 불필요한 설정 파일 제외
+//	if (activeProfile == "local") {
+//		exclude("application-prod.properties")
+//	} else if (activeProfile == "prod") {
+//		exclude("application-local.properties")
+//	}
+//}

--- a/src/main/java/grep/neogul_coder/global/config/security/SecurityConfig.java
+++ b/src/main/java/grep/neogul_coder/global/config/security/SecurityConfig.java
@@ -83,6 +83,8 @@ public class SecurityConfig {
                         "/reissue",
                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
                         "/webjars/**",
+                        "/h2-console/**",
+                        "/favicon.ico",
                         "/error").permitAll()
                     .anyRequest().authenticated()
             )


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #32 

## 📌 과제 설명
인증 서버 배포를 위해 로컬·테스트 환경에서 H2 콘솔과 파비콘을 열어두고, Google Maven Repo 및 DB/GCP 관련 의존성을 정리하여 배포가 되도록 설정했습니다.

## 👩‍💻 요구 사항과 구현 내용 
- h2-console, favicon 접근 허용 경로 추가
- google 저장소 및 h2, gcp 관련 의존성 추가


## ✅ PR 포인트 & 궁금한 점
혹시 몰라 h2와 GCP 의존성은 삭제하지 않고 주석 처리 해놨습니다.
GCP
