### PR TITLE
[EA3-99] 회원 관련 swagger 구현

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
@@ -1,12 +1,16 @@
 package grep.neogul_coder.domain.users.controller;
 
+import grep.neogul_coder.domain.users.controller.dto.UpdatePasswordRequest;
+import grep.neogul_coder.domain.users.controller.dto.UpdateProfileRequest;
 import grep.neogul_coder.global.response.ApiResponse;
 import grep.neogul_coder.domain.users.controller.dto.SignUpRequest;
 import grep.neogul_coder.domain.users.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -21,8 +25,22 @@ public class UserController {
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<Void> signUp(@Valid @RequestBody SignUpRequest request) {
+    public ApiResponse<Void> signUp(@RequestBody SignUpRequest request) {
         usersService.signUp(request);
-        return ApiResponse.noContent("회원가입이 정상적으로 처리되었습니다.");
+        return ApiResponse.noContent();
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<Void> updateProfile(@PathVariable Long id,
+        @RequestBody UpdateProfileRequest request) {
+        usersService.updateProfile(id,request.getNickname(),request.getProfileImgUrl());
+        return ApiResponse.noContent();
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<Void> updatePassword(@PathVariable Long id,
+        @RequestBody UpdatePasswordRequest request) {
+        usersService.updatePassword(id,request.getPassword(),request.getNewPassword(),request.getNewPasswordCheck());
+        return ApiResponse.noContent();
     }
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
@@ -2,12 +2,13 @@ package grep.neogul_coder.domain.users.controller;
 
 import grep.neogul_coder.domain.users.controller.dto.UpdatePasswordRequest;
 import grep.neogul_coder.domain.users.controller.dto.UpdateProfileRequest;
+import grep.neogul_coder.domain.users.controller.dto.PasswordRequest;
 import grep.neogul_coder.global.response.ApiResponse;
 import grep.neogul_coder.domain.users.controller.dto.SignUpRequest;
 import grep.neogul_coder.domain.users.service.UserService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -43,4 +44,12 @@ public class UserController implements UserSpecification {
         usersService.updatePassword(id,request.getPassword(),request.getNewPassword(),request.getNewPasswordCheck());
         return ApiResponse.noContent();
     }
+
+    @DeleteMapping("/delete/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id,
+        @RequestBody PasswordRequest request) {
+        usersService.deleteUser(id,request.getPassword());
+        return ApiResponse.noContent();
+    }
+
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
@@ -25,5 +25,4 @@ public class UserController {
         usersService.signUp(request);
         return ApiResponse.noContent("회원가입이 정상적으로 처리되었습니다.");
     }
-
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
-public class UserController {
+public class UserController implements UserSpecification {
 
     private final UserService usersService;
 
@@ -30,14 +30,14 @@ public class UserController {
         return ApiResponse.noContent();
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/update/profile/{id}")
     public ApiResponse<Void> updateProfile(@PathVariable Long id,
         @RequestBody UpdateProfileRequest request) {
         usersService.updateProfile(id,request.getNickname(),request.getProfileImgUrl());
         return ApiResponse.noContent();
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/update/password/{id}")
     public ApiResponse<Void> updatePassword(@PathVariable Long id,
         @RequestBody UpdatePasswordRequest request) {
         usersService.updatePassword(id,request.getPassword(),request.getNewPassword(),request.getNewPasswordCheck());

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
@@ -1,9 +1,11 @@
 package grep.neogul_coder.domain.users.controller;
 
 import grep.neogul_coder.domain.users.controller.dto.SignUpRequest;
-import grep.neogul_coder.domain.users.entity.User;
+import grep.neogul_coder.domain.users.controller.dto.UpdatePasswordRequest;
+import grep.neogul_coder.domain.users.controller.dto.UpdateProfileRequest;
 import grep.neogul_coder.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -11,11 +13,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface UserSpecification {
 
     @Operation(summary = "회원 가입", description = "회원 정보를 저장합니다.")
-    ApiResponse<Void> signUp(SignUpRequest request);
+    ApiResponse<Void> signUp(@RequestBody SignUpRequest request);
 
     @Operation(summary = "회원 프로필 수정", description = "회원 프로필을 수정합니다.")
-    ApiResponse<Void> updateProfile(@PathVariable Long id);
+    ApiResponse<Void> updateProfile(@PathVariable Long id,@RequestBody UpdateProfileRequest request);
 
     @Operation(summary = "회원 비밀번호 수정", description = "회원 비밀번호를 수정합니다.")
-    ApiResponse<Void> updatePassword(@PathVariable Long id);
+    ApiResponse<Void> updatePassword(@PathVariable Long id, @RequestBody UpdatePasswordRequest request);
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
@@ -1,9 +1,11 @@
 package grep.neogul_coder.domain.users.controller;
 
 import grep.neogul_coder.domain.users.controller.dto.SignUpRequest;
+import grep.neogul_coder.domain.users.entity.User;
 import grep.neogul_coder.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "User", description = "회원 API")
 public interface UserSpecification {
@@ -11,4 +13,9 @@ public interface UserSpecification {
     @Operation(summary = "회원 가입", description = "회원 정보를 저장합니다.")
     ApiResponse<Void> signUp(SignUpRequest request);
 
+    @Operation(summary = "회원 프로필 수정", description = "회원 프로필을 수정합니다.")
+    ApiResponse<Void> updateProfile(@PathVariable Long id);
+
+    @Operation(summary = "회원 비밀번호 수정", description = "회원 비밀번호를 수정합니다.")
+    ApiResponse<Void> updatePassword(@PathVariable Long id);
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
@@ -1,5 +1,6 @@
 package grep.neogul_coder.domain.users.controller;
 
+import grep.neogul_coder.domain.users.controller.dto.PasswordRequest;
 import grep.neogul_coder.domain.users.controller.dto.SignUpRequest;
 import grep.neogul_coder.domain.users.controller.dto.UpdatePasswordRequest;
 import grep.neogul_coder.domain.users.controller.dto.UpdateProfileRequest;
@@ -20,4 +21,7 @@ public interface UserSpecification {
 
     @Operation(summary = "회원 비밀번호 수정", description = "회원 비밀번호를 수정합니다.")
     ApiResponse<Void> updatePassword(@PathVariable Long id, @RequestBody UpdatePasswordRequest request);
+
+    @Operation(summary = "회원 상태 삭제로 변경", description = "회원 상태를 삭제로 변경합니다.")
+    ApiResponse<Void> delete(@PathVariable Long id, @RequestBody PasswordRequest request);
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/PasswordRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/PasswordRequest.java
@@ -1,0 +1,12 @@
+package grep.neogul_coder.domain.users.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class PasswordRequest {
+
+    @NotBlank(message = "비밀번호를 입력하세요")
+    String password;
+
+}

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/SignUpRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/SignUpRequest.java
@@ -7,23 +7,25 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
+@Schema(description = "회원가입")
 public class SignUpRequest {
 
     @NotBlank(message = "이메일을 입력해주세요.")
     @Email
-    @Schema(example = "example@example.com")
+    @Schema(description = "이메일", example = "example@example.com")
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
+    @Schema(description = "비밀번호", example = "example123")
     private String password;
 
     @NotBlank(message = "비밀번호 확인을 입력해주세요.")
-    @Schema(description = "비밀번호 확인")
+    @Schema(description = "비밀번호 확인", example = "example123")
     private String passwordCheck;
 
     @NotBlank(message = "닉네임은 필수 입력 사항입니다.")
     @Size(min = 2, max = 10, message = "닉네임은 최소 2자, 최대 10자까지 입력 가능합니다.")
-    @Schema(example = "홍길동")
+    @Schema(description = "닉네임", example = "홍길동")
     private String nickname;
 
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/SignUpRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/SignUpRequest.java
@@ -22,7 +22,7 @@ public class SignUpRequest {
     private String passwordCheck;
 
     @NotBlank(message = "닉네임은 필수 입력 사항입니다.")
-    @Size(min = 2, max = 8, message = "닉네임은 최소 2자, 최대 10자까지 입력 가능합니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 최소 2자, 최대 10자까지 입력 가능합니다.")
     @Schema(example = "홍길동")
     private String nickname;
 

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdatePasswordRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdatePasswordRequest.java
@@ -1,0 +1,18 @@
+package grep.neogul_coder.domain.users.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UpdatePasswordRequest {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요")
+    String password;
+
+    @NotBlank(message = "변겯할 비밀번호를 입력해주세요")
+    String newPassword;
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요")
+    String newPasswordCheck;
+
+}

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdatePasswordRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdatePasswordRequest.java
@@ -1,18 +1,23 @@
 package grep.neogul_coder.domain.users.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
+@Schema(description = "비밀번호 변경")
 public class UpdatePasswordRequest {
 
     @NotBlank(message = "현재 비밀번호를 입력해주세요")
+    @Schema(description = "현재 비밀번호", example = "oldPassword")
     String password;
 
     @NotBlank(message = "변겯할 비밀번호를 입력해주세요")
+    @Schema(description = "새 비밀번호", example = "newPassword")
     String newPassword;
 
     @NotBlank(message = "비밀번호 확인을 입력해주세요")
+    @Schema(description = "새 비밀번호 확인", example = "newPassword")
     String newPasswordCheck;
 
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdateProfileRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdateProfileRequest.java
@@ -1,0 +1,11 @@
+package grep.neogul_coder.domain.users.controller.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdateProfileRequest {
+
+    String nickname;
+    String profileImgUrl;
+
+}

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdateProfileRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/UpdateProfileRequest.java
@@ -1,11 +1,16 @@
 package grep.neogul_coder.domain.users.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
+@Schema(description = "유저 프로필 변경")
 public class UpdateProfileRequest {
 
+    @Schema(description = "닉네임", example = "example")
     String nickname;
+
+    @Schema(description = "프로필 이미지")
     String profileImgUrl;
 
 }

--- a/src/main/java/grep/neogul_coder/domain/users/entity/User.java
+++ b/src/main/java/grep/neogul_coder/domain/users/entity/User.java
@@ -26,14 +26,11 @@ public class User extends BaseEntity {
 
     String oauthProvider;
 
-    @NotBlank
     @Email
     String email;
 
-    @NotBlank
     String password;
 
-    @NotBlank
     String nickname;
 
     String profileImageUrl;

--- a/src/main/java/grep/neogul_coder/domain/users/entity/User.java
+++ b/src/main/java/grep/neogul_coder/domain/users/entity/User.java
@@ -8,14 +8,15 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
 @Entity
 @Getter
 @Builder
+@Table(name = "member")
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/grep/neogul_coder/domain/users/entity/User.java
+++ b/src/main/java/grep/neogul_coder/domain/users/entity/User.java
@@ -41,6 +41,25 @@ public class User extends BaseEntity {
 
     Boolean isDeleted;
 
+    public static User UserInit(String email, String password, String nickname) {
+        return User.builder()
+            .email(email)
+            .password(password)
+            .nickname(nickname)
+            .isDeleted(false)
+            .role(Role.ROLE_USER)
+            .build();
+    }
+
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
     protected User(Long id, String oauthId, String oauthProvider, String email, String password,
         String nickname, String profileImageUrl, Role role, Boolean isDeleted) {
         this.id = id;
@@ -55,15 +74,5 @@ public class User extends BaseEntity {
     }
 
     protected User() {
-    }
-
-    public static User UserInit(String email, String password, String nickname) {
-        return User.builder()
-            .email(email)
-            .password(password)
-            .nickname(nickname)
-            .isDeleted(false)
-            .role(Role.ROLE_USER)
-            .build();
     }
 }

--- a/src/main/java/grep/neogul_coder/domain/users/entity/User.java
+++ b/src/main/java/grep/neogul_coder/domain/users/entity/User.java
@@ -60,6 +60,10 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
+    public void delete() {
+        this.isDeleted = true;
+    }
+
     protected User(Long id, String oauthId, String oauthProvider, String email, String password,
         String nickname, String profileImageUrl, Role role, Boolean isDeleted) {
         this.id = id;

--- a/src/main/java/grep/neogul_coder/domain/users/repository/UserRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/users/repository/UserRepository.java
@@ -12,4 +12,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
+
 }

--- a/src/main/java/grep/neogul_coder/domain/users/repository/UserRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/users/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package grep.neogul_coder.domain.users.repository;
 
 import grep.neogul_coder.domain.users.entity.User;
+import jakarta.validation.constraints.NotBlank;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/grep/neogul_coder/domain/users/repository/UserRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/users/repository/UserRepository.java
@@ -4,6 +4,8 @@ import grep.neogul_coder.domain.users.entity.User;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
+++ b/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
@@ -35,6 +35,27 @@ public class UserService {
         userRepository.save(User.UserInit(request.getEmail(),encodedPassword, request.getNickname()));
     }
 
+    public void updateProfile(Long id, String nickname, String profileImageUrl) {
+        User user = userRepository.findById(id).orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+        user.updateProfile(nickname, profileImageUrl);
+    }
+
+    public void updatePassword(Long id, String password, String newPassword, String newPasswordCheck) {
+        User user = userRepository.findById(id).orElseThrow(()-> new RuntimeException("회원이 존재하지 않습니다."));
+
+        if(isNotMatchCurrentPassword(password,user.getPassword())) {
+            throw new RuntimeException("비밀번호를 다시 확인해주세요");
+        }
+
+        if(isNotMatchPasswordCheck(password, newPassword)) {
+            throw new RuntimeException("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        }
+
+        String encodedPassword = encodingPassword(newPassword);
+
+        user.updatePassword(encodedPassword);
+    }
+
     private boolean isDuplicateEmail(String email) {
         return userRepository.findByEmail(email).isPresent();
     }
@@ -49,6 +70,14 @@ public class UserService {
 
     private String encodingPassword(String password) {
         return passwordEncoder.encode(password);
+    }
+
+    private boolean isNotMatchCurrentPassword(String currentPassword, String password) {
+        return !passwordEncoder.matches(password, currentPassword);
+    }
+
+    private boolean isNotMatchPasswordCheck(String password, String passwordCheck) {
+        return !passwordEncoder.matches(password, passwordCheck);
     }
 
 }

--- a/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
+++ b/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
@@ -56,6 +56,17 @@ public class UserService {
         user.updatePassword(encodedPassword);
     }
 
+    public void deleteUser(Long id, String password) {
+
+        User user = userRepository.findById(id).orElseThrow(()-> new RuntimeException("회원이 존재하지 않습니다."));
+
+        if(isNotMatchCurrentPassword(password,user.getPassword())) {
+            throw new RuntimeException("비밀번호를 다시 확인해주세요");
+        }
+
+        user.delete();
+    }
+
     private boolean isDuplicateEmail(String email) {
         return userRepository.findByEmail(email).isPresent();
     }
@@ -79,7 +90,6 @@ public class UserService {
     private boolean isNotMatchPasswordCheck(String password, String passwordCheck) {
         return !passwordEncoder.matches(password, passwordCheck);
     }
-
 }
 
 

--- a/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
+++ b/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
@@ -1,6 +1,5 @@
 package grep.neogul_coder.domain.users.service;
 
-import grep.neogul_coder.global.auth.code.Role;
 import grep.neogul_coder.domain.users.controller.dto.SignUpRequest;
 import grep.neogul_coder.domain.users.entity.User;
 import grep.neogul_coder.domain.users.repository.UserRepository;
@@ -23,32 +22,34 @@ public class UserService {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
 
-        if(isNotMatchPassword(request.getPassword(), request.getPasswordCheck())){
+        if (isNotMatchPasswordCheck(request.getPassword(), request.getPasswordCheck())) {
             throw new IllegalArgumentException("비밀번호 확인이 일치하지 않습니다.");
         }
 
-        if(isDuplicateNickname(request.getNickname())) {
+        if (isDuplicateNickname(request.getNickname())) {
             throw new IllegalArgumentException("동일한 닉네임이 존재합니다.");
         }
 
         String encodedPassword = encodingPassword(request.getPassword());
-        userRepository.save(User.UserInit(request.getEmail(),encodedPassword, request.getNickname()));
+        userRepository.save(
+            User.UserInit(request.getEmail(), encodedPassword, request.getNickname()));
     }
 
     public void updateProfile(Long id, String nickname, String profileImageUrl) {
-        User user = userRepository.findById(id).orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+        User user = findUser(id);
         user.updateProfile(nickname, profileImageUrl);
     }
 
-    public void updatePassword(Long id, String password, String newPassword, String newPasswordCheck) {
-        User user = userRepository.findById(id).orElseThrow(()-> new RuntimeException("회원이 존재하지 않습니다."));
+    public void updatePassword(Long id, String password, String newPassword,
+        String newPasswordCheck) {
+        User user = findUser(id);
 
-        if(isNotMatchCurrentPassword(password,user.getPassword())) {
+        if (isNotMatchCurrentPassword(password, user.getPassword())) {
             throw new RuntimeException("비밀번호를 다시 확인해주세요");
         }
 
-        if(isNotMatchPasswordCheck(password, newPassword)) {
-            throw new RuntimeException("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        if (isNotMatchPasswordCheck(newPassword, newPasswordCheck)) {
+            throw new IllegalArgumentException("비밀번호 확인이 일치하지 않습니다.");
         }
 
         String encodedPassword = encodingPassword(newPassword);
@@ -58,13 +59,17 @@ public class UserService {
 
     public void deleteUser(Long id, String password) {
 
-        User user = userRepository.findById(id).orElseThrow(()-> new RuntimeException("회원이 존재하지 않습니다."));
+        User user = findUser(id);
 
-        if(isNotMatchCurrentPassword(password,user.getPassword())) {
+        if (isNotMatchCurrentPassword(password, user.getPassword())) {
             throw new RuntimeException("비밀번호를 다시 확인해주세요");
         }
 
         user.delete();
+    }
+
+    private User findUser(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
     }
 
     private boolean isDuplicateEmail(String email) {
@@ -75,20 +80,16 @@ public class UserService {
         return userRepository.findByNickname(nickname).isPresent();
     }
 
-    private boolean isNotMatchPassword(String password, String passwordCheck) {
-        return !passwordEncoder.matches(password, passwordCheck);
-    }
-
     private String encodingPassword(String password) {
         return passwordEncoder.encode(password);
     }
 
-    private boolean isNotMatchCurrentPassword(String currentPassword, String password) {
-        return !passwordEncoder.matches(password, currentPassword);
+    private boolean isNotMatchCurrentPassword(String inputPassword, String storedPassword) {
+        return !passwordEncoder.matches(inputPassword, storedPassword);
     }
 
     private boolean isNotMatchPasswordCheck(String password, String passwordCheck) {
-        return !passwordEncoder.matches(password, passwordCheck);
+        return !password.equals(passwordCheck);
     }
 }
 

--- a/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
+++ b/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
@@ -27,6 +27,10 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호 확인이 일치하지 않습니다.");
         }
 
+        if(isDuplicateNickname(request.getNickname())) {
+            throw new IllegalArgumentException("동일한 닉네임이 존재합니다.");
+        }
+
         String encodedPassword = encodingPassword(request.getPassword());
         userRepository.save(User.UserInit(request.getEmail(),encodedPassword, request.getNickname()));
     }
@@ -35,12 +39,16 @@ public class UserService {
         return userRepository.findByEmail(email).isPresent();
     }
 
-    private String encodingPassword(String password) {
-        return passwordEncoder.encode(password);
+    private boolean isDuplicateNickname(String nickname) {
+        return userRepository.findByNickname(nickname).isPresent();
     }
 
     private boolean isNotMatchPassword(String password, String passwordCheck) {
         return !passwordEncoder.matches(password, passwordCheck);
+    }
+
+    private String encodingPassword(String password) {
+        return passwordEncoder.encode(password);
     }
 
 }

--- a/src/main/java/grep/neogul_coder/global/auth/service/AuthService.java
+++ b/src/main/java/grep/neogul_coder/global/auth/service/AuthService.java
@@ -98,7 +98,7 @@ public class AuthService {
         User user = usersRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException("해당 이메일의 유저가 없습니다."));
 
-        return user.getOauthProvider().equals("Google");
+        return "Google".equals(user.getOauthProvider());
     }
 
 }

--- a/src/main/java/grep/neogul_coder/global/auth/service/AuthService.java
+++ b/src/main/java/grep/neogul_coder/global/auth/service/AuthService.java
@@ -10,6 +10,8 @@ import grep.neogul_coder.global.auth.payload.LoginRequest;
 import grep.neogul_coder.global.auth.repository.UserBlackListRepository;
 import grep.neogul_coder.domain.users.entity.User;
 import grep.neogul_coder.domain.users.repository.UserRepository;
+import grep.neogul_coder.global.exception.GoogleUserLoginException;
+import grep.neogul_coder.global.response.ResponseCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +39,7 @@ public class AuthService {
     public TokenDto signin(LoginRequest loginRequest) {
 
         if(isGoogleUser(loginRequest.getEmail())){
-            throw new IllegalArgumentException("Google 로그인으로 로그인 해주세요.");
+            throw new GoogleUserLoginException(ResponseCode.SECURITY_INCIDENT);
         }
 
         UsernamePasswordAuthenticationToken authenticationToken =

--- a/src/main/java/grep/neogul_coder/global/config/security/SecurityConfig.java
+++ b/src/main/java/grep/neogul_coder/global/config/security/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
                         "/oauth2/**",
                         "/login/**",
                         "/signup",
+                        "/api/users/**",
                         "/reissue",
                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
                         "/webjars/**",

--- a/src/main/java/grep/neogul_coder/global/exception/GoogleUserLoginException.java
+++ b/src/main/java/grep/neogul_coder/global/exception/GoogleUserLoginException.java
@@ -1,0 +1,14 @@
+package grep.neogul_coder.global.exception;
+
+import grep.neogul_coder.global.response.ResponseCode;
+
+public class GoogleUserLoginException extends CommonException {
+
+    public GoogleUserLoginException(ResponseCode code) {
+        super(code);
+    }
+
+    public GoogleUserLoginException(ResponseCode code, Exception e) {
+        super(code, e);
+    }
+}

--- a/src/main/java/grep/neogul_coder/global/exception/advice/AuthExceptionAdvice.java
+++ b/src/main/java/grep/neogul_coder/global/exception/advice/AuthExceptionAdvice.java
@@ -1,6 +1,7 @@
 package grep.neogul_coder.global.exception.advice;
 
 import grep.neogul_coder.global.exception.AuthApiException;
+import grep.neogul_coder.global.exception.GoogleUserLoginException;
 import grep.neogul_coder.global.response.ApiResponse;
 import grep.neogul_coder.global.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,14 @@ public class AuthExceptionAdvice {
         return ResponseEntity
             .status(HttpStatus.UNAUTHORIZED)
             .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+    }
+
+    @ResponseBody
+    @ExceptionHandler(GoogleUserLoginException.class)
+    public ResponseEntity<ApiResponse<String>> googleUserLoginExHandler(GoogleUserLoginException ex) {
+        return ResponseEntity
+            .status(ex.code().getStatus())
+            .body(ApiResponse.error(ResponseCode.SECURITY_INCIDENT));
     }
 
 }

--- a/src/main/java/grep/neogul_coder/global/response/ApiResponse.java
+++ b/src/main/java/grep/neogul_coder/global/response/ApiResponse.java
@@ -10,6 +10,10 @@ public record ApiResponse<T>(
         return new ApiResponse<>(ResponseCode.OK.getCode(), ResponseCode.OK.getMessage(), data);
     }
 
+    public static <T> ApiResponse<T> noContent(){
+        return new ApiResponse<>(ResponseCode.OK.getCode(), ResponseCode.OK.getMessage(), null);
+    }
+
     public static <T> ApiResponse<T> noContent(String message){
         return new ApiResponse<>(ResponseCode.OK.getCode(), message, null);
     }

--- a/src/main/java/grep/neogul_coder/global/response/ApiResponse.java
+++ b/src/main/java/grep/neogul_coder/global/response/ApiResponse.java
@@ -25,4 +25,8 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> error(ResponseCode code, T data){
         return new ApiResponse<>(code.getCode(), code.getMessage(), data);
     }
+
+    public static <T> ApiResponse<T> error(String message){
+        return new ApiResponse<>(ResponseCode.SECURITY_INCIDENT.getCode(), message, null);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#28 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
회원 Api Swagger 관련 구현
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
Google 사용자가 일반 로그인을 통해 로그인 하는 것을 차단
회원 수정을 위한 swagger 작성과 기능 구현
회원 탈퇴를 위한 swagger 작성과 기능 구현
회원과 관련된 패스워드 인코딩과 비교 과정에서 에러 발생 확인 / 해결 완료
![image](https://github.com/user-attachments/assets/047df147-251b-453c-accc-a64029ec33cb)
![image](https://github.com/user-attachments/assets/67db0f46-cce2-4b39-8e4d-32aefc59cac5)
![image](https://github.com/user-attachments/assets/1ec5de07-c8c4-4b88-9f2a-47f8ba2334a4)
![image](https://github.com/user-attachments/assets/e8f712aa-dcb9-49f3-8271-8da2d05a85c9)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
ApiResponse관련하여 형식에 대한 수정 논의 후 수정 필요