### PR TITLE
[EA3-78] feature: 스터디 커뮤니티 게시글 엔티티 및 스웨거 작성(+pageresponse 생성)

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/studypost/Category.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/Category.java
@@ -1,0 +1,19 @@
+package grep.neogul_coder.domain.studypost;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리: NOTICE(공지), FREE(자유)")
+public enum Category {
+  NOTICE("공지"),
+  FREE("자유");
+
+  private final String korean;
+
+  Category(String korean) { this.korean = korean; }
+
+  @JsonValue
+  public String toJson() {
+    return korean;
+  }
+}

--- a/src/main/java/grep/neogul_coder/domain/studypost/StudyPost.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/StudyPost.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.NotBlank;
 public class StudyPost extends BaseEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/grep/neogul_coder/domain/studypost/StudyPost.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/StudyPost.java
@@ -1,0 +1,45 @@
+package grep.neogul_coder.domain.studypost;
+
+import grep.neogul_coder.domain.study.Study;
+import grep.neogul_coder.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+public class StudyPost extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "study_id", nullable = false)
+  private Study study;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @NotBlank(message = "제목은 필수입니다.")
+  @Column(nullable = false)
+  private String title;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Category category;
+
+  @NotBlank(message = "내용은 필수입니다.")
+  @Column(nullable = false)
+  private String content;
+
+  @Column(nullable = false)
+  private boolean isDeleted = false;
+}

--- a/src/main/java/grep/neogul_coder/domain/studypost/controller/StudyPostController.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/controller/StudyPostController.java
@@ -1,0 +1,55 @@
+package grep.neogul_coder.domain.studypost.controller;
+
+import grep.neogul_coder.domain.studypost.dto.StudyPostDetailResponse;
+import grep.neogul_coder.domain.studypost.dto.StudyPostListResponse;
+import grep.neogul_coder.domain.studypost.dto.StudyPostRequest;
+import grep.neogul_coder.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/studies/{studyId}/posts")
+public class StudyPostController implements StudyPostSpecification {
+
+  @PostMapping
+  public ApiResponse<Void> create(
+      @PathVariable("studyId") Long studyId,
+      @RequestBody @Valid StudyPostRequest request
+  ) {
+    return ApiResponse.noContent();
+  }
+
+  @GetMapping("/all")
+  public ApiResponse<List<StudyPostListResponse>> findAllWithoutPagination(
+      @PathVariable("studyId") Long studyId
+  ) {
+    List<StudyPostListResponse> content = List.of(new StudyPostListResponse());
+    return ApiResponse.success(content);
+  }
+
+  @GetMapping("/{postId}")
+  public ApiResponse<StudyPostDetailResponse> findOne(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId
+  ) {
+    return ApiResponse.success(new StudyPostDetailResponse());
+  }
+
+  @PutMapping("/{postId}")
+  public ApiResponse<Void> update(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId,
+      @RequestBody @Valid StudyPostRequest request
+  ) {
+    return ApiResponse.noContent();
+  }
+
+  @DeleteMapping("/{postId}")
+  public ApiResponse<Void> delete(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId
+  ) {
+    return ApiResponse.noContent();
+  }
+}

--- a/src/main/java/grep/neogul_coder/domain/studypost/controller/StudyPostSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/controller/StudyPostSpecification.java
@@ -1,0 +1,45 @@
+package grep.neogul_coder.domain.studypost.controller;
+
+import grep.neogul_coder.domain.studypost.dto.StudyPostDetailResponse;
+import grep.neogul_coder.domain.studypost.dto.StudyPostListResponse;
+import grep.neogul_coder.domain.studypost.dto.StudyPostRequest;
+import grep.neogul_coder.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+
+@Tag(name = "Study-Post", description = "스터디 게시판 API")
+public interface StudyPostSpecification {
+
+  @Operation(summary = "게시글 생성", description = "스터디에 새로운 게시글을 작성합니다.")
+  ApiResponse<Void> create(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Valid StudyPostRequest request
+  );
+
+  @Operation(summary = "게시글 목록 전체 조회", description = "스터디의 게시글 전체 목록을 조회합니다.")
+  ApiResponse<List<StudyPostListResponse>> findAllWithoutPagination(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId
+  );
+
+  @Operation(summary = "게시글 상세 조회", description = "특정 게시글의 상세 정보를 조회합니다.")
+  ApiResponse<StudyPostDetailResponse> findOne(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "15") Long postId
+  );
+
+  @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
+  ApiResponse<Void> update(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "15") Long postId,
+      @Valid StudyPostRequest request
+  );
+
+  @Operation(summary = "게시글 삭제", description = "특정 게시글을 삭제합니다.")
+  ApiResponse<Void> delete(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "15") Long postId
+  );
+}

--- a/src/main/java/grep/neogul_coder/domain/studypost/dto/StudyPostDetailResponse.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/dto/StudyPostDetailResponse.java
@@ -1,0 +1,40 @@
+package grep.neogul_coder.domain.studypost.dto;
+
+import grep.neogul_coder.domain.comment.dto.CommentResponse;
+import grep.neogul_coder.domain.studypost.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "스터디 게시글 상세 응답 DTO")
+public class StudyPostDetailResponse {
+
+  @Schema(description = "게시글 ID", example = "10")
+  private Long id;
+
+  @Schema(description = "제목", example = "모든 국민은 직업선택의 자유를 가진다.")
+  private String title;
+
+  @Schema(description = "카테고리: NOTICE(공지), FREE(자유)", example = "NOTICE")
+  private Category category;
+
+  @Schema(description = "본문", example = "국회는 의원의 자격을 심사하며, 의원을 징계할 있다.")
+  private String content;
+
+  @Schema(description = "작성일", example = "2025-07-10T14:00:00")
+  private LocalDateTime createdDate;
+
+  @Schema(description = "작성자 닉네임", example = "너굴코더")
+  private String nickname;
+
+  @Schema(description = "작성자 프로필 이미지 URL", example = "https://cdn.example.com/profile.jpg")
+  private String profileImageUrl;
+
+  @Schema(description = "댓글 수", example = "3")
+  private int commentCount;
+
+  @Schema(description = "댓글 목록")
+  private List<CommentResponse> comments;
+}

--- a/src/main/java/grep/neogul_coder/domain/studypost/dto/StudyPostListResponse.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/dto/StudyPostListResponse.java
@@ -1,0 +1,29 @@
+package grep.neogul_coder.domain.studypost.dto;
+
+import grep.neogul_coder.domain.studypost.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "스터디 게시글 목록 응답 DTO")
+public class StudyPostListResponse {
+
+  @Schema(description = "게시글 ID", example = "12")
+  private Long id;
+
+  @Schema(description = "제목", example = "모든 국민은 직업선택의 자유를 가진다.")
+  private String title;
+
+  @Schema(description = "카테고리: NOTICE(공지), FREE(자유)", example = "NOTICE")
+  private Category category;
+
+  @Schema(description = "본문", example = "국회는 의원의 자격을 심사하며, 의원을 징계할 있다.")
+  private String content;
+
+  @Schema(description = "작성일", example = "2025-07-10T14:32:00")
+  private LocalDateTime createdDate;
+
+  @Schema(description = "댓글 수", example = "3")
+  private int commentCount;
+}

--- a/src/main/java/grep/neogul_coder/domain/studypost/dto/StudyPostRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/studypost/dto/StudyPostRequest.java
@@ -1,0 +1,22 @@
+package grep.neogul_coder.domain.studypost.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "스터디 게시글 저장/수정 요청 DTO")
+public class StudyPostRequest {
+
+  @Schema(description = "제목", example = "스터디 공지")
+  @NotBlank
+  private String title;
+
+  @Schema(description = "카테고리: NOTICE(공지), FREE(자유)", example = "NOTICE")
+  @NotBlank
+  private String category;
+
+  @Schema(description = "내용", example = "오늘은 각자 공부한 내용에 대해 발표가 있는 날 입니다!")
+  @NotBlank
+  private String content;
+}

--- a/src/main/java/grep/neogul_coder/global/response/PageResponse.java
+++ b/src/main/java/grep/neogul_coder/global/response/PageResponse.java
@@ -1,0 +1,46 @@
+package grep.neogul_coder.global.response;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@RequiredArgsConstructor
+public class PageResponse<T> {
+
+  private final String url;
+  private final Page<T> page;
+  private final int pageButtonCnt;
+
+  public String url(){
+    return url;
+  }
+
+  public int currentNumber(){
+    return page.getNumber() + 1;
+  }
+
+  public int prevPage(){
+    return Math.max(currentNumber() - 1, 1);
+  }
+
+  public int nextPage(){
+    return Math.min(currentNumber() + 1, calcTotalPage());
+  }
+
+  public int startNumber(){
+    return Math.floorDiv(page.getNumber(), pageButtonCnt) * pageButtonCnt + 1;
+  }
+
+  public int endNumber(){
+    return Math.min(startNumber() + pageButtonCnt - 1, calcTotalPage());
+  }
+
+  public List<T> content(){
+    return page.getContent();
+  }
+
+  private int calcTotalPage(){
+    int totalPage = page.getTotalPages();
+    return totalPage == 0 ? 1 : totalPage;
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #14 

## 📌 과제 설명
스터디 커뮤니티 게시글 엔티티 및 스웨거 작성(+공통 pageresponse 생성)

## 👩‍💻 요구 사항과 구현 내용 
- 게시글 생성
- 게시글 수정
- 게시글 삭제
- 게시글 상세 조회
- 게시글 목록 전체 조회
- 공통 pageresponse 생성
<img width="596" height="547" alt="스크린샷 2025-07-11 23 35 05" src="https://github.com/user-attachments/assets/f5102f99-a915-48d2-ae1f-b19e377c5c60" />
<img width="749" height="692" alt="스크린샷 2025-07-11 23 35 15" src="https://github.com/user-attachments/assets/be7b36e2-ae0f-43d5-ac64-c138fa3cb85d" />
<img width="682" height="745" alt="스크린샷 2025-07-11 23 35 29" src="https://github.com/user-attachments/assets/30945a1c-d46b-45ea-8ba5-eed5a91a0ed6" />
<img width="672" height="902" alt="스크린샷 2025-07-11 23 35 43" src="https://github.com/user-attachments/assets/9fd5f0a6-2ccc-4b0d-92c2-04387db68921" />
<img width="662" height="934" alt="스크린샷 2025-07-11 23 35 59" src="https://github.com/user-attachments/assets/0d635a30-ff81-4e3e-b243-fc1e8fa7a8b9" />
