### PR TITLE
[EA3-79] feature: 스터디 게시판 댓글 엔티티 및 API 작성

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/comment/Comment.java
+++ b/src/main/java/grep/neogul_coder/domain/comment/Comment.java
@@ -1,0 +1,26 @@
+package grep.neogul_coder.domain.comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long postId;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false, length = 100)
+  @NotBlank(message = "내용은 필수입니다.")
+  private String content;
+}

--- a/src/main/java/grep/neogul_coder/domain/comment/Comment.java
+++ b/src/main/java/grep/neogul_coder/domain/comment/Comment.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotBlank;
 public class Comment {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
   @Column(nullable = false)

--- a/src/main/java/grep/neogul_coder/domain/comment/controller/CommentController.java
+++ b/src/main/java/grep/neogul_coder/domain/comment/controller/CommentController.java
@@ -1,0 +1,48 @@
+package grep.neogul_coder.domain.comment.controller;
+
+import grep.neogul_coder.domain.comment.dto.CommentRequest;
+import grep.neogul_coder.domain.comment.dto.CommentResponse;
+import grep.neogul_coder.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/studies/{studyId}/posts/{postId}/comments")
+public class CommentController implements CommentSpecification {
+
+  @PostMapping
+  public ApiResponse<Void> createComment(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId,
+      @RequestBody @Valid CommentRequest request
+  ) {
+    return ApiResponse.create();
+  }
+
+  @GetMapping("/{commentId}")
+  public ApiResponse<CommentResponse> findComment(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId,
+      @PathVariable("commentId") Long commentId
+  ) {
+    return ApiResponse.success(new CommentResponse());
+  }
+
+  @GetMapping("/all")
+  public ApiResponse<List<CommentResponse>> findAllComments(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId
+  ) {
+    return ApiResponse.success(List.of(new CommentResponse()));
+  }
+
+  @DeleteMapping("/{commentId}")
+  public ApiResponse<Void> deleteComment(
+      @PathVariable("studyId") Long studyId,
+      @PathVariable("postId") Long postId,
+      @PathVariable("commentId") Long commentId
+  ) {
+    return ApiResponse.noContent();
+  }
+}

--- a/src/main/java/grep/neogul_coder/domain/comment/controller/CommentSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/comment/controller/CommentSpecification.java
@@ -1,0 +1,40 @@
+package grep.neogul_coder.domain.comment.controller;
+
+import grep.neogul_coder.domain.comment.dto.CommentRequest;
+import grep.neogul_coder.domain.comment.dto.CommentResponse;
+import grep.neogul_coder.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "Study-Comment", description = "스터디 게시판 댓글 API")
+public interface CommentSpecification {
+
+  @Operation(summary = "댓글 생성", description = "스터디 게시글에 댓글을 생성합니다.")
+  ApiResponse<Void> createComment(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "10") Long postId,
+      CommentRequest request
+  );
+
+  @Operation(summary = "댓글 단건 조회", description = "특정 댓글의 상세 내용을 조회합니다.")
+  ApiResponse<CommentResponse> findComment(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "10") Long postId,
+      @Parameter(description = "댓글 ID", example = "100") Long commentId
+  );
+
+  @Operation(summary = "댓글 목록 전체 조회", description = "해당 게시글의 댓글 전체를 조회합니다.")
+  ApiResponse<List<CommentResponse>> findAllComments(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "10") Long postId
+  );
+
+  @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+  ApiResponse<Void> deleteComment(
+      @Parameter(description = "스터디 ID", example = "1") Long studyId,
+      @Parameter(description = "게시글 ID", example = "10") Long postId,
+      @Parameter(description = "댓글 ID", example = "100") Long commentId
+  );
+}

--- a/src/main/java/grep/neogul_coder/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,14 @@
+package grep.neogul_coder.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "스터디 게시글 댓글 요청 DTO")
+public class CommentRequest {
+
+  @Schema(description = "댓글 내용", example = "유익한 게시글이네욥!")
+  @NotBlank
+  private String content;
+}

--- a/src/main/java/grep/neogul_coder/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/grep/neogul_coder/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,25 @@
+package grep.neogul_coder.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "스터디 게시글 댓글 응답 DTO")
+public class CommentResponse {
+
+  @Schema(description = "댓글 ID", example = "100")
+  private Long id;
+
+  @Schema(description = "작성자 닉네임", example = "너굴코더")
+  private String nickname;
+
+  @Schema(description = "작성자 프로필 이미지 URL", example = "https://cdn.example.com/profile.jpg")
+  private String profileImageUrl;
+
+  @Schema(description = "댓글 내용", example = "정말 좋은 정보 감사합니다!")
+  private String content;
+
+  @Schema(description = "작성일", example = "2025-07-10T14:45:00")
+  private LocalDateTime createdAt;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #15

## 📌 과제 설명 
스터디 게시글 댓글 엔티티 및 스웨거 작성

## 👩‍💻 요구 사항과 구현 내용 
- 댓글 생성
- 댓글 조회
- 댓글 목록 조회
- 댓글 삭제

- <img width="703" height="675" alt="스크린샷 2025-07-12 00 19 38" src="https://github.com/user-attachments/assets/cab45f28-1e02-442b-880d-b6ddea94654c" />
<img width="662" height="862" alt="스크린샷 2025-07-12 00 25 33" src="https://github.com/user-attachments/assets/e662b9e1-029c-4ef8-aa34-c9ad089aa72a" />
<img width="671" height="912" alt="스크린샷 2025-07-12 00 25 50" src="https://github.com/user-attachments/assets/791e473c-cfe5-4759-a9c1-d3424f719bc4" />
<img width="761" height="932" alt="스크린샷 2025-07-12 00 26 08" src="https://github.com/user-attachments/assets/8015fa54-5962-4ec7-809b-9b755707dbf2" />