### PR TITLE
[EA3-73] refactor : 채팅방 엔티티 수정

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/groupchat/entity/GroupChatRoom.java
+++ b/src/main/java/grep/neogul_coder/domain/groupchat/entity/GroupChatRoom.java
@@ -14,7 +14,6 @@ public class GroupChatRoom extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long roomId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_id")
-    private Study study;
+    @JoinColumn(name = "study_id", nullable = false)
+    private Long studyId;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
#9 

## 📌 과제 설명 
실시간 메시지 처리 특성상, 채팅에서 스터디 정보를 자주 직접 조회할 일은 많지 않다고 판단해서 
연관을 끊고 studyId만 유지하도록 리팩터링하였습니다!