### PR TITLE
[EA3-74] refactor : 컨트롤러 restfull 리팩터링

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalenderController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalenderController.java
@@ -8,30 +8,32 @@ import java.util.List;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/calendar/personal")
+@RequestMapping("/api/users/{userId}/calendar")
 public class PersonalCalenderController implements PersonalCalenderSpecification {
 
     @PostMapping
-    public ApiResponse<Void> create(@RequestParam Long userId, @RequestBody PersonalCalenderRequest request) {
+    public ApiResponse<Void> create(
+        @PathVariable("userId") Long userId,
+        @RequestBody PersonalCalenderRequest request) {
         return ApiResponse.noContent();
     }
 
     @GetMapping
-    public ApiResponse<List<PersonalCalenderResponse>> findAll(@RequestParam Long userId) {
+    public ApiResponse<List<PersonalCalenderResponse>> findAll(@PathVariable("userId") Long userId) {
         return ApiResponse.success(List.of(new PersonalCalenderResponse()));
     }
 
 
     @GetMapping("/{scheduleId}")
     public ApiResponse<PersonalCalenderResponse> findOne(
-        @PathVariable("scheduleId") Long scheduleId,
-        @RequestParam Long userId
+        @PathVariable("userId") Long userId,
+        @PathVariable("scheduleId") Long scheduleId
     ) {
         return ApiResponse.success(new PersonalCalenderResponse());
     }
     @GetMapping("/day")
     public ApiResponse<List<PersonalCalenderResponse>> findByDate(
-        @RequestParam Long userId,
+        @PathVariable("userId") Long userId,
         @RequestParam String date
     ) {
         return ApiResponse.success(List.of(new PersonalCalenderResponse()));
@@ -39,8 +41,8 @@ public class PersonalCalenderController implements PersonalCalenderSpecification
 
     @PutMapping("/{scheduleId}")
     public ApiResponse<Void> update(
+        @PathVariable("userId") Long userId,
         @PathVariable("scheduleId") Long scheduleId,
-        @RequestParam Long userId,
         @RequestBody PersonalCalenderRequest request
     ) {
         return ApiResponse.noContent();
@@ -48,8 +50,8 @@ public class PersonalCalenderController implements PersonalCalenderSpecification
 
     @DeleteMapping("/{scheduleId}")
     public ApiResponse<Void> delete(
-        @PathVariable("scheduleId") Long scheduleId,
-        @RequestParam Long userId
+        @PathVariable("userId") Long userId,
+        @PathVariable("scheduleId") Long scheduleId
     ) {
         return ApiResponse.noContent();
     }

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalenderSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalenderSpecification.java
@@ -18,65 +18,72 @@ public interface PersonalCalenderSpecification {
 
     @Operation(
         summary = "개인 일정 생성",
-        description = "사용자의 개인 일정을 생성합니다.\n\n예: `/api/calendar/personal?userId=123`"
+        description = "사용자의 개인 일정을 생성합니다.\n\n예: `/api/users/{userId}/calendar`"
     )
     ApiResponse<Void> create(
-        @Parameter(name = "userId", description = "일정을 생성할 사용자 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long userId,
+        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("userId") Long userId,
         @RequestBody PersonalCalenderRequest request
     );
 
     @Operation(
         summary = "개인 일정 전체 조회",
-        description = "사용자 ID 기준으로 모든 개인 일정을 조회합니다.\n\n예: `/api/calendar/personal?userId=123`"
+        description = "사용자 ID 기준으로 모든 개인 일정을 조회합니다.\n\n예: `/api/users/{userId}/calendar`"
     )
     ApiResponse<List<PersonalCalenderResponse>> findAll(
-        @Parameter(name = "userId", description = "일정을 조회할 사용자 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long userId
+        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("userId") Long userId
     );
 
     @Operation(
         summary = "개인 일정 상세 조회",
-        description = "사용자의 특정 일정 상세정보를 조회합니다.\n\n예: `/api/calendar/personal/{scheduleId}?userId=123`"
+        description = "사용자의 특정 일정 상세정보를 조회합니다.\n\n예: `/api/users/{userId}/calendar/{scheduleId}`"
     )
     ApiResponse<PersonalCalenderResponse> findOne(
-        @PathVariable("scheduleId") Long scheduleId,
-        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long userId
+        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("userId") Long userId,
+
+        @Parameter(name = "scheduleId", description = "일정 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("scheduleId") Long scheduleId
     );
 
     @Operation(
         summary = "개인 일정 날짜별 조회",
         description = "특정 사용자 ID와 날짜에 해당하는 모든 개인 일정을 조회합니다.\n\n" +
-            "예: `/api/calendar/personal/day?userId=1&date=2025-07-17`"
+            "예: `/api/users/{userId}/calendar/day?date=2025-07-17`"
     )
     ApiResponse<List<PersonalCalenderResponse>> findByDate(
-        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long userId,
+        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("userId") Long userId,
 
-        @Parameter(name = "date", description = "조회할 날짜 (예: 2025-07-17)", required = true, in = ParameterIn.QUERY)
+        @Parameter(name = "date", description = "조회할 날짜 (yyyy-MM-dd)", required = true, in = ParameterIn.QUERY)
         @RequestParam String date
     );
 
 
     @Operation(
         summary = "개인 일정 수정",
-        description = "사용자의 특정 일정을 수정합니다.\n\n예: `/api/calendar/personal/{scheduleId}?userId=123`"
+        description = "사용자의 특정 일정을 수정합니다.\n\n예: `/api/users/{userId}/calendar/{scheduleId}`"
     )
     ApiResponse<Void> update(
+        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("userId") Long userId,
+
+        @Parameter(name = "scheduleId", description = "일정 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("scheduleId") Long scheduleId,
-        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long userId,
+
         @RequestBody PersonalCalenderRequest request
     );
 
     @Operation(
         summary = "개인 일정 삭제",
-        description = "사용자의 특정 일정을 삭제합니다.\n\n예: `/api/calendar/personal/{scheduleId}?userId=123`"
+        description = "사용자의 특정 일정을 삭제합니다.\n\n예: `/api/users/{userId}/calendar/{scheduleId}`"
     )
     ApiResponse<Void> delete(
-        @PathVariable("scheduleId") Long scheduleId,
-        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long userId
+        @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("userId") Long userId,
+
+        @Parameter(name = "scheduleId", description = "일정 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("scheduleId") Long scheduleId
     );
 }

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalenderController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalenderController.java
@@ -9,23 +9,23 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/calendar/team")
+@RequestMapping("/api/teams/{teamId}/calendar")
 public class TeamCalenderController implements TeamCalenderSpecification {
 
     @PostMapping
-    public ApiResponse<Void> create(@RequestParam Long teamId, @RequestBody TeamCalenderRequest request) {
+    public ApiResponse<Void> create(@PathVariable("teamId") Long teamId, @RequestBody TeamCalenderRequest request) {
         return ApiResponse.noContent();
     }
 
     @GetMapping
-    public ApiResponse<List<TeamCalenderResponse>> findAll(@RequestParam Long teamId) {
+    public ApiResponse<List<TeamCalenderResponse>> findAll(@PathVariable("teamId") Long teamId) {
         return ApiResponse.success(List.of(new TeamCalenderResponse()));
     }
 
     @GetMapping("/{scheduleId}")
     public ApiResponse<TeamCalenderResponse> findOne(
-        @PathVariable("scheduleId") Long scheduleId,
-        @RequestParam Long teamId
+        @PathVariable("teamId") Long teamId,
+        @PathVariable("scheduleId") Long scheduleId
     ) {
         return ApiResponse.success(new TeamCalenderResponse());
     }
@@ -33,7 +33,7 @@ public class TeamCalenderController implements TeamCalenderSpecification {
 
     @GetMapping("/day")
     public ApiResponse<List<TeamCalenderResponse>> findByDate(
-        @RequestParam Long teamId,
+        @PathVariable("teamId") Long teamId,
         @RequestParam String date
     ) {
         return ApiResponse.success(List.of(new TeamCalenderResponse()));
@@ -41,8 +41,8 @@ public class TeamCalenderController implements TeamCalenderSpecification {
 
     @PutMapping("/{scheduleId}")
     public ApiResponse<Void> update(
+        @PathVariable("teamId") Long teamId,
         @PathVariable("scheduleId") Long scheduleId,
-        @RequestParam Long teamId,
         @RequestBody TeamCalenderRequest request
     ) {
         return ApiResponse.noContent();
@@ -50,8 +50,8 @@ public class TeamCalenderController implements TeamCalenderSpecification {
 
     @DeleteMapping("/{scheduleId}")
     public ApiResponse<Void> delete(
-        @PathVariable("scheduleId") Long scheduleId,
-        @RequestParam Long teamId
+        @PathVariable("teamId") Long teamId,
+        @PathVariable("scheduleId") Long scheduleId
     ) {
         return ApiResponse.noContent();
     }

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalenderSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalenderSpecification.java
@@ -19,34 +19,35 @@ public interface TeamCalenderSpecification {
     @Operation(
         summary = "팀 일정 전체 조회",
         description = "특정 팀 ID에 해당하는 모든 일정을 조회합니다.\n\n" +
-            "예: `/api/calendar/team?teamId=123`"
+            "예: `/api/teams/{teamId}/calendar`"
     )
     ApiResponse<List<TeamCalenderResponse>> findAll(
-        @Parameter(name = "teamId", description = "조회할 팀 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long teamId
+        @Parameter(name = "teamId", description = "조회할 팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("teamId") Long teamId
     );
 
 
     @Operation(
         summary = "팀 일정 상세 조회",
         description = "특정 팀의 특정 일정 상세정보를 조회합니다.\n\n" +
-            "예: `/api/calendar/team/{scheduleId}?teamId=123`"
+            "예: `/api/teams/{teamId}/calendar/{scheduleId}`"
     )
     ApiResponse<TeamCalenderResponse> findOne(
-        @PathVariable("scheduleId") Long scheduleId,
-        @Parameter(name = "teamId", description = "조회할 팀 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long teamId
+        @Parameter(name = "teamId", description = "팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("teamId") Long teamId,
+        @Parameter(name = "scheduleId", description = "일정 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("scheduleId") Long scheduleId
     );
 
 
     @Operation(
         summary = "팀 일정 날짜별 조회",
         description = "특정 팀의 특정 날짜(yyyy-MM-dd)에 등록된 일정들을 조회합니다.\n\n" +
-            "예: `/api/calendar/team/day?teamId=123&date=2025-07-17`"
+            "예: `/api/teams/{teamId}/calendar/day?date=2025-07-17`"
     )
     ApiResponse<List<TeamCalenderResponse>> findByDate(
-        @Parameter(name = "teamId", description = "조회할 팀 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long teamId,
+        @Parameter(name = "teamId", description = "조회할 팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("teamId") Long teamId,
 
         @Parameter(name = "date", description = "조회할 날짜 (yyyy-MM-dd)", required = true, in = ParameterIn.QUERY)
         @RequestParam String date
@@ -56,34 +57,36 @@ public interface TeamCalenderSpecification {
     @Operation(
         summary = "팀 일정 생성",
         description = "특정 팀 ID에 새로운 일정을 생성합니다.\n\n" +
-            "예: `/api/calendar/team?teamId=123` "
+            "예: `/api/teams/{teamId}/calendar`"
     )
     ApiResponse<Void> create(
-        @Parameter(name = "teamId", description = "일정을 생성할 팀 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long teamId,
+        @Parameter(name = "teamId", description = "일정을 생성할 팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("teamId") Long teamId,
         @RequestBody TeamCalenderRequest request
     );
 
     @Operation(
         summary = "팀 일정 수정",
         description = "기존 팀 일정을 수정합니다.\n\n" +
-            "예: `/api/calendar/team/{scheduleId}?teamId=123`"
+            "예: `/api/teams/{teamId}/calendar/{scheduleId}`"
     )
     ApiResponse<Void> update(
+        @Parameter(name = "teamId", description = "팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("teamId") Long teamId,
+        @Parameter(name = "scheduleId", description = "일정 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("scheduleId") Long scheduleId,
-        @Parameter(name = "teamId", description = "수정할 팀 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long teamId,
         @RequestBody TeamCalenderRequest request
     );
 
     @Operation(
         summary = "팀 일정 삭제",
         description = "기존 팀 일정을 삭제합니다.\n\n" +
-            "예: `/api/calendar/team/{scheduleId}?teamId=123`"
+            "예: `/api/teams/{teamId}/calendar/{scheduleId}`"
     )
     ApiResponse<Void> delete(
-        @PathVariable("scheduleId") Long scheduleId,
-        @Parameter(name = "teamId", description = "삭제할 팀 ID", required = true, in = ParameterIn.QUERY)
-        @RequestParam Long teamId
+        @Parameter(name = "teamId", description = "팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("teamId") Long teamId,
+        @Parameter(name = "scheduleId", description = "일정 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("scheduleId") Long scheduleId
     );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
#10 

## 📌 과제 설명 

기존 쿼리 파라미터 방식에서 경로 변수(PATH) 기반의 방식으로 변경하여 일관성 있게 구성했습니다.

## 👩‍💻 요구 사항과 구현 내용

[개인 캘린더 관련]
기존 /api/calendar/personal?userId=... → /api/users/{userId}/calendar 구조로 변경

PersonalCalenderSpecification 내부 전체 메서드의 @Parameter, @PathVariable 적용 통일

[팀 캘린더 관련]
기존 /api/calendar/team?teamId=... → /api/teams/{teamId}/calendar 구조로 변경

TeamCalenderSpecification에도 동일하게 @PathVariable 방식 적용


