### PR TITLE
[EA3-112] fix: 날짜별 조회 날짜 계산 로직 수정 및 일정 등록 시 Id 값 반환

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarController.java
@@ -20,11 +20,11 @@ public class PersonalCalendarController implements PersonalCalendarSpecification
 
     // 사용자 개인 일정 등록 API
     @PostMapping
-    public ApiResponse<Void> create(
+    public ApiResponse<Long> create(
         @PathVariable("userId") Long userId,
         @Valid @RequestBody PersonalCalendarRequest request) {
-        personalCalendarService.create(userId, request);
-        return ApiResponse.noContent();
+        Long calendarId = personalCalendarService.create(userId, request);
+        return ApiResponse.success(calendarId);  // 생성된 일정 ID 반환
     }
 
     // 사용자 개인 일정 전체 조회 API

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarSpecification.java
@@ -20,7 +20,7 @@ public interface PersonalCalendarSpecification {
         summary = "개인 일정 생성",
         description = "사용자의 개인 일정을 생성합니다.\n\n예: `/api/users/{userId}/calendar`"
     )
-    ApiResponse<Void> create(
+    ApiResponse<Long> create(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("userId") Long userId,
         @RequestBody PersonalCalendarRequest request

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarController.java
@@ -23,13 +23,13 @@ public class TeamCalendarController implements TeamCalendarSpecification {
 
     // 팀 일정 생성
     @PostMapping
-    public ApiResponse<Void> create(
+    public ApiResponse<Long> create(
         @AuthenticationPrincipal(expression = "userId") Long userId,              // 인증된 사용자의 ID를 자동 주입받음
         @PathVariable("studyId") Long studyId,
         @Valid @RequestBody TeamCalendarRequest request
     ) {
-        teamCalendarService.create(studyId, userId, request);
-        return ApiResponse.noContent();
+        Long calendarId = teamCalendarService.create(studyId, userId, request);
+        return ApiResponse.success(calendarId);  // 생성된 일정 ID 반환
     }
 
     // 전체 일정 조회 API

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarSpecification.java
@@ -48,7 +48,7 @@ public interface TeamCalendarSpecification {
         description = "특정 팀 ID에 새로운 일정을 생성합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar`"
     )
-    ApiResponse<Void> create(
+    ApiResponse<Long> create(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "일정을 생성할 팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId,

--- a/src/main/java/grep/neogul_coder/domain/calender/repository/PersonalCalendarQueryRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/repository/PersonalCalendarQueryRepository.java
@@ -20,13 +20,9 @@ public class PersonalCalendarQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<PersonalCalendar> findByUserIdAndDate(Long userId, LocalDate date) {
+    public List<PersonalCalendar> findByUserIdAndDate(Long userId, LocalDateTime start, LocalDateTime end) {
         // Q타입 : 쿼리DSL 에서 사용하는 엔티티 기반 쿼리 클래스
         QPersonalCalendar pc = QPersonalCalendar.personalCalendar;
-
-        // 조회 기준 : 하루의 시작과 끝 시간
-        LocalDateTime start = date.atStartOfDay();                          // 2025-07-23 00:00
-        LocalDateTime end = date.plusDays(1).atStartOfDay();      // 2025-07-24 00:00
 
         // 쿼리 실행:
         // 해당 유저의 일정 중

--- a/src/main/java/grep/neogul_coder/domain/calender/repository/PersonalCalendarQueryRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/repository/PersonalCalendarQueryRepository.java
@@ -25,8 +25,8 @@ public class PersonalCalendarQueryRepository {
         QPersonalCalendar pc = QPersonalCalendar.personalCalendar;
 
         // 조회 기준 : 하루의 시작과 끝 시간
-        LocalDateTime start = date.atStartOfDay();          // 00:00:00
-        LocalDateTime end = date.atTime(LocalTime.MAX);     // 23:59:59.999
+        LocalDateTime start = date.atStartOfDay();                          // 2025-07-23 00:00
+        LocalDateTime end = date.plusDays(1).atStartOfDay();      // 2025-07-24 00:00
 
         // 쿼리 실행:
         // 해당 유저의 일정 중
@@ -38,7 +38,7 @@ public class PersonalCalendarQueryRepository {
             .where(
                 pc.userId.eq(userId),
                 pc.activated.eq(true),
-                calendar.scheduledStart.loe(end),
+                calendar.scheduledStart.lt(end),
                 calendar.scheduledEnd.goe(start)
             )
             .fetch();

--- a/src/main/java/grep/neogul_coder/domain/calender/repository/TeamCalendarQueryRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/repository/TeamCalendarQueryRepository.java
@@ -24,8 +24,9 @@ public class TeamCalendarQueryRepository {
         // 쿼리DSL용 Q타입: 팀 캘린더
         QTeamCalendar tc = QTeamCalendar.teamCalendar;
 
-        LocalDateTime start = date.atStartOfDay();          // 00:00:00
-        LocalDateTime end = date.atTime(LocalTime.MAX);     // 23:59:59.999...
+        // 조회 기준 : 하루의 시작과 끝 시간
+        LocalDateTime start = date.atStartOfDay();                          // 2025-07-23 00:00
+        LocalDateTime end = date.plusDays(1).atStartOfDay();      // 2025-07-24 00:00
 
         // 쿼리:
         // - 해당 studyId인 팀 일정 중
@@ -37,7 +38,7 @@ public class TeamCalendarQueryRepository {
             .where(
                 tc.studyId.eq(studyId),
                 tc.activated.eq(true),
-                calendar.scheduledStart.loe(end),
+                calendar.scheduledStart.lt(end),
                 calendar.scheduledEnd.goe(start)
             )
             .fetch();

--- a/src/main/java/grep/neogul_coder/domain/calender/repository/TeamCalendarQueryRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/repository/TeamCalendarQueryRepository.java
@@ -20,13 +20,9 @@ public class TeamCalendarQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<TeamCalendar> findByStudyIdAndDate(Long studyId, LocalDate date) {
+    public List<TeamCalendar> findByStudyIdAndDate(Long studyId, LocalDateTime start, LocalDateTime end) {
         // 쿼리DSL용 Q타입: 팀 캘린더
         QTeamCalendar tc = QTeamCalendar.teamCalendar;
-
-        // 조회 기준 : 하루의 시작과 끝 시간
-        LocalDateTime start = date.atStartOfDay();                          // 2025-07-23 00:00
-        LocalDateTime end = date.plusDays(1).atStartOfDay();      // 2025-07-24 00:00
 
         // 쿼리:
         // - 해당 studyId인 팀 일정 중

--- a/src/main/java/grep/neogul_coder/domain/calender/service/PersonalCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/PersonalCalendarService.java
@@ -45,22 +45,25 @@ public class PersonalCalendarService {
     // 특정 날짜의 일정 필터링해서 조회
     public List<PersonalCalendarResponse> findByDate(Long userId, LocalDate date) {
         User user = userService.get(userId);
+        LocalDateTime start = date.atStartOfDay();                      // 2025-07-23 00:00
+        LocalDateTime end = date.plusDays(1).atStartOfDay();   // 2025-07-24 00:00
 
         return personalCalendarQueryRepository
-            .findByUserIdAndDate(userId, date).stream()
+            .findByUserIdAndDate(userId, start, end).stream()
             .map(pc -> PersonalCalendarResponse.from(pc, user))
             .toList();
     }
 
     // 개인 일정 생성
     @Transactional
-    public void create(Long userId, PersonalCalendarRequest request) {
+    public Long create(Long userId, PersonalCalendarRequest request) {
         // 필수 필드  입력 안할 시 유효성 예외 발생
         validateRequiredFields(request); // 메서드로 분리
 
         Calendar calendar = request.toCalendar();
         PersonalCalendar personalCalendar = new PersonalCalendar(userId, calendar);
         personalCalendarRepository.save(personalCalendar);
+        return calendar.getId();
     }
 
     // 개인 일정 수정

--- a/src/main/java/grep/neogul_coder/domain/calender/service/PersonalCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/PersonalCalendarService.java
@@ -46,9 +46,6 @@ public class PersonalCalendarService {
     public List<PersonalCalendarResponse> findByDate(Long userId, LocalDate date) {
         User user = userService.get(userId);
 
-        LocalDateTime startOfDay = date.atStartOfDay();                 // 00:00:00
-        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);            // 23:59:59.999999999
-
         return personalCalendarQueryRepository
             .findByUserIdAndDate(userId, date).stream()
             .map(pc -> PersonalCalendarResponse.from(pc, user))

--- a/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
@@ -45,8 +45,6 @@ public class TeamCalendarService {
     }
 
     public List<TeamCalendarResponse> findByDate(Long studyId, LocalDate date) {
-        LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime endOfDay = date.atTime(LocalTime.MAX); // 23:59:59.999..
 
         return teamCalendarQueryRepository
             .findByStudyIdAndDate(studyId, date).stream()

--- a/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
@@ -46,8 +46,11 @@ public class TeamCalendarService {
 
     public List<TeamCalendarResponse> findByDate(Long studyId, LocalDate date) {
 
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay();
+
         return teamCalendarQueryRepository
-            .findByStudyIdAndDate(studyId, date).stream()
+            .findByStudyIdAndDate(studyId, start, end).stream()
             .map(tc -> {
                 User user = userService.get(tc.getUserId());
                 return TeamCalendarResponse.from(tc, user);
@@ -56,12 +59,14 @@ public class TeamCalendarService {
     }
 
     @Transactional
-    public void create(Long studyId, Long userId, TeamCalendarRequest request) {
+    public Long create(Long studyId, Long userId, TeamCalendarRequest request) {
         validateRequest(request);
 
         Calendar calendar = request.toCalendar();
         TeamCalendar teamCalendar = new TeamCalendar(studyId, userId, calendar);
         teamCalendarRepository.save(teamCalendar);
+
+        return calendar.getId();
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
#55 

## 📌 과제 설명 
등록된 일정의 시작시간이 20일 00:00:00으로 등록 했었을 때 19일로 날짜별 일정 조회를 하면 20일 일정이 조회 되는 오류가 있었습니다
따라서 기존 00:00:00 ~ 23:59:59.999 구간에서 발생할 수 있는 아주 미묘한 경계 조건 오류를 해결했습니다.

## 👩‍💻 요구 사항과 구현 내용 

## 조회 구간 로직 개선

- LocalDateTime end = date.atTime(LocalTime.MAX);
→ LocalDateTime end = date.plusDays(1).atStartOfDay();

- 기존에는 하루의 **끝(23:59:59.999)**을 사용했으나,
다음날 00:00:00 전까지의 구간으로 정확하게 조회하도록 변경.

## 쿼리 조건 수정

- calendar.scheduledStart.loe(end)
→ calendar.scheduledStart.lt(end)

경계값 포함 여부를 lt()로 수정하여 다음날 00:00:00 데이터를 잘못 포함하는 문제 해결.

