### PR TITLE
[EA3-112] refactor : 개인/팀 캘린더 일정 등록 API 개선

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarController.java
@@ -23,8 +23,8 @@ public class PersonalCalendarController implements PersonalCalendarSpecification
     public ApiResponse<Long> create(
         @PathVariable("userId") Long userId,
         @Valid @RequestBody PersonalCalendarRequest request) {
-        Long calendarId = personalCalendarService.create(userId, request);
-        return ApiResponse.success(calendarId);  // 생성된 일정 ID 반환
+        Long personalCalendarId  = personalCalendarService.create(userId, request);
+        return ApiResponse.success(personalCalendarId );  // 생성된 일정 ID 반환
     }
 
     // 사용자 개인 일정 전체 조회 API

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/PersonalCalendarSpecification.java
@@ -18,7 +18,7 @@ public interface PersonalCalendarSpecification {
 
     @Operation(
         summary = "개인 일정 생성",
-        description = "사용자의 개인 일정을 생성합니다.\n\n예: `/api/users/{userId}/calendar`"
+        description = "사용자의 개인 일정을 생성하고, 생성된 개인 일정 ID를 반환합니다. \n\n예: `/api/users/{userId}/calendar`"
     )
     ApiResponse<Long> create(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarController.java
@@ -28,8 +28,8 @@ public class TeamCalendarController implements TeamCalendarSpecification {
         @PathVariable("studyId") Long studyId,
         @Valid @RequestBody TeamCalendarRequest request
     ) {
-        Long calendarId = teamCalendarService.create(studyId, userId, request);
-        return ApiResponse.success(calendarId);  // 생성된 일정 ID 반환
+        Long teamCalendarId = teamCalendarService.create(studyId, userId, request);
+        return ApiResponse.success(teamCalendarId);  // 생성된 일정 ID 반환
     }
 
     // 전체 일정 조회 API

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarSpecification.java
@@ -45,7 +45,7 @@ public interface TeamCalendarSpecification {
 
     @Operation(
         summary = "팀 일정 생성",
-        description = "특정 팀 ID에 새로운 일정을 생성합니다.\n\n" +
+        description = "팀 일정을 생성하고 생성된 팀 일정 ID를 반환합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar`"
     )
     ApiResponse<Long> create(

--- a/src/main/java/grep/neogul_coder/domain/calender/service/PersonalCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/PersonalCalendarService.java
@@ -63,7 +63,7 @@ public class PersonalCalendarService {
         Calendar calendar = request.toCalendar();
         PersonalCalendar personalCalendar = new PersonalCalendar(userId, calendar);
         personalCalendarRepository.save(personalCalendar);
-        return calendar.getId();
+        return personalCalendar.getId();
     }
 
     // 개인 일정 수정

--- a/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
@@ -66,7 +66,7 @@ public class TeamCalendarService {
         TeamCalendar teamCalendar = new TeamCalendar(studyId, userId, calendar);
         teamCalendarRepository.save(teamCalendar);
 
-        return calendar.getId();
+        return teamCalendar.getId();
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
-closed #55 

## 📌 과제 설명 

- 개인/팀 캘린더 생성 API 개선
생성 시 DB에 저장된 실제 PersonalCalendarId / TeamCalendarId를 반환하도록 수정하여 프론트에서 등록된 일정 ID를 바로 활용할 수 있도록 개선하였습니다.

