### PR TITLE
[EA3-173] 회원가입 시 메일을 통한 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
 
     // WebSocket + STOMP 통신용
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// 이메일 전송 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
@@ -4,6 +4,7 @@ import grep.neogul_coder.domain.users.controller.dto.request.PasswordRequest;
 import grep.neogul_coder.domain.users.controller.dto.request.SignUpRequest;
 import grep.neogul_coder.domain.users.controller.dto.request.UpdatePasswordRequest;
 import grep.neogul_coder.domain.users.controller.dto.response.UserResponse;
+import grep.neogul_coder.domain.users.service.EmailVerificationService;
 import grep.neogul_coder.domain.users.service.UserService;
 import grep.neogul_coder.global.auth.Principal;
 import grep.neogul_coder.global.response.ApiResponse;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController implements UserSpecification {
 
     private final UserService usersService;
+    private final EmailVerificationService verificationService;
 
     @GetMapping("/me")
     public ApiResponse<UserResponse> get(@AuthenticationPrincipal Principal principal) {
@@ -75,4 +78,22 @@ public class UserController implements UserSpecification {
         usersService.signUp(request);
         return ApiResponse.noContent();
     }
+
+    @PostMapping("/mail/send")
+    public ApiResponse<Void> sendCode(@RequestParam String email) {
+        verificationService.sendVerificationEmail(email);
+        return ApiResponse.noContent();
+    }
+
+    @PostMapping("/mail/verify")
+    public ApiResponse<Void> verifyCode(
+        @RequestParam String email,
+        @RequestParam String code
+    ) {
+        boolean result = verificationService.verifyCode(email, code);
+        return result ?
+            ApiResponse.noContent() :
+            ApiResponse.badRequest();
+    }
+
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserController.java
@@ -8,14 +8,22 @@ import grep.neogul_coder.domain.users.service.UserService;
 import grep.neogul_coder.global.auth.Principal;
 import grep.neogul_coder.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,9 +46,9 @@ public class UserController implements UserSpecification {
 
     @PutMapping(value = "/update/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> updateProfile(
-            @AuthenticationPrincipal Principal principal,
-            @RequestPart("nickname") String nickname,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+        @AuthenticationPrincipal Principal principal,
+        @RequestPart("nickname") String nickname,
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) throws IOException {
         usersService.updateProfile(principal.getUserId(), nickname, profileImage);
         return ApiResponse.noContent();
@@ -48,14 +56,15 @@ public class UserController implements UserSpecification {
 
     @PutMapping("/update/password")
     public ApiResponse<Void> updatePassword(@AuthenticationPrincipal Principal principal,
-                                            @Valid @RequestBody UpdatePasswordRequest request) {
-        usersService.updatePassword(principal.getUserId(), request.getPassword(), request.getNewPassword(), request.getNewPasswordCheck());
+        @Valid @RequestBody UpdatePasswordRequest request) {
+        usersService.updatePassword(principal.getUserId(), request.getPassword(),
+            request.getNewPassword(), request.getNewPasswordCheck());
         return ApiResponse.noContent();
     }
 
     @DeleteMapping("/delete/me")
     public ApiResponse<Void> delete(@AuthenticationPrincipal Principal principal,
-                                    @RequestBody @Valid PasswordRequest request) {
+        @RequestBody @Valid PasswordRequest request) {
         usersService.deleteUser(principal.getUserId(), request.getPassword());
         return ApiResponse.noContent();
     }
@@ -66,5 +75,4 @@ public class UserController implements UserSpecification {
         usersService.signUp(request);
         return ApiResponse.noContent();
     }
-
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/UserSpecification.java
@@ -7,10 +7,12 @@ import grep.neogul_coder.domain.users.controller.dto.response.UserResponse;
 import grep.neogul_coder.global.auth.Principal;
 import grep.neogul_coder.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,4 +38,19 @@ public interface UserSpecification {
     @Operation(summary = "회원 상태 삭제로 변경", description = "회원 상태를 삭제로 변경합니다.")
     ApiResponse<Void> delete(@AuthenticationPrincipal Principal principal,
         @RequestBody PasswordRequest request);
+
+    @Operation(summary = "이메일 인증 코드 발송", description = "입력한 이메일 주소로 인증 코드를 발송합니다.")
+    ApiResponse<Void> sendCode(
+        @Parameter(description = "인증 코드를 보낼 이메일 주소", required = true, example = "user@example.com")
+        @RequestParam String email
+    );
+
+    @Operation(summary = "이메일 인증 코드 검증", description = "사용자가 입력한 인증 코드가 올바른지 검증합니다.")
+    ApiResponse<Void> verifyCode(
+        @Parameter(description = "인증 요청한 이메일 주소", required = true, example = "user@example.com")
+        @RequestParam String email,
+
+        @Parameter(description = "사용자가 입력한 인증 코드", required = true, example = "123456")
+        @RequestParam String code
+    );
 }

--- a/src/main/java/grep/neogul_coder/domain/users/controller/dto/response/UserResponse.java
+++ b/src/main/java/grep/neogul_coder/domain/users/controller/dto/response/UserResponse.java
@@ -20,24 +20,29 @@ public class UserResponse {
     @Schema(description = "회원 프로필 이미지", example = "profileImageUrl")
     private String profileImageUrl;
 
+    @Schema(description = "회원 OAuth 정보", example = "Google")
+    private String oauth;
+
     @Schema(description = "Role")
     private Role role;
 
     @Builder
-    private UserResponse(Long id, String email, String nickname,String profileImageUrl, Role role) {
+    private UserResponse(Long id, String email, String nickname,String profileImageUrl, String oauth ,Role role) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.oauth = oauth;
         this.role = role;
     }
 
-    public static UserResponse toUserResponse(Long id, String email, String nickname,String profileImageUrl, Role role){
+    public static UserResponse toUserResponse(Long id, String email, String nickname,String profileImageUrl, String oauth, Role role){
         return UserResponse.builder()
             .id(id)
             .email(email)
             .nickname(nickname)
             .profileImageUrl(profileImageUrl)
+            .oauth(oauth)
             .role(role)
             .build();
     }

--- a/src/main/java/grep/neogul_coder/domain/users/entity/User.java
+++ b/src/main/java/grep/neogul_coder/domain/users/entity/User.java
@@ -2,7 +2,13 @@ package grep.neogul_coder.domain.users.entity;
 
 import grep.neogul_coder.global.auth.code.Role;
 import grep.neogul_coder.global.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,11 +40,12 @@ public class User extends BaseEntity {
 
     public static User UserInit(String email, String password, String nickname) {
         return User.builder()
-                .email(email)
-                .password(password)
-                .nickname(nickname)
-                .role(Role.ROLE_USER)
-                .build();
+            .email(email)
+            .password(password)
+            .nickname(nickname)
+            .role(Role.ROLE_USER)
+            .activated(true)
+            .build();
     }
 
     public void updateProfile(String nickname, String profileImageUrl) {
@@ -58,7 +65,7 @@ public class User extends BaseEntity {
 
     @Builder
     private User(Long id, String oauthId, String oauthProvider, String email, String password,
-                 String nickname, String profileImageUrl, Role role) {
+        String nickname, String profileImageUrl, Boolean activated, Role role) {
         this.id = id;
         this.oauthId = oauthId;
         this.oauthProvider = oauthProvider;
@@ -66,6 +73,7 @@ public class User extends BaseEntity {
         this.password = password;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.activated = activated;
         this.role = role;
     }
 

--- a/src/main/java/grep/neogul_coder/domain/users/exception/NotVerifiedEmailException.java
+++ b/src/main/java/grep/neogul_coder/domain/users/exception/NotVerifiedEmailException.java
@@ -1,0 +1,11 @@
+package grep.neogul_coder.domain.users.exception;
+
+import grep.neogul_coder.global.exception.business.BusinessException;
+import grep.neogul_coder.global.response.code.ErrorCode;
+
+public class NotVerifiedEmailException extends BusinessException {
+
+    public NotVerifiedEmailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/grep/neogul_coder/domain/users/exception/UnActivatedUserException.java
+++ b/src/main/java/grep/neogul_coder/domain/users/exception/UnActivatedUserException.java
@@ -1,0 +1,11 @@
+package grep.neogul_coder.domain.users.exception;
+
+import grep.neogul_coder.global.exception.business.BusinessException;
+import grep.neogul_coder.global.response.code.ErrorCode;
+
+public class UnActivatedUserException extends BusinessException {
+
+    public UnActivatedUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/grep/neogul_coder/domain/users/exception/advice/UserAdvice.java
+++ b/src/main/java/grep/neogul_coder/domain/users/exception/advice/UserAdvice.java
@@ -2,6 +2,7 @@ package grep.neogul_coder.domain.users.exception.advice;
 
 import grep.neogul_coder.domain.users.exception.EmailDuplicationException;
 import grep.neogul_coder.domain.users.exception.NicknameDuplicatedException;
+import grep.neogul_coder.domain.users.exception.NotVerifiedEmailException;
 import grep.neogul_coder.domain.users.exception.PasswordNotMatchException;
 import grep.neogul_coder.domain.users.exception.PasswordUncheckException;
 import grep.neogul_coder.domain.users.exception.UserNotFoundException;
@@ -48,6 +49,13 @@ public class UserAdvice {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.errorWithoutData(UserErrorCode.IS_DUPLICATED_NICKNAME));
+    }
+
+    @ ExceptionHandler(NotVerifiedEmailException.class)
+    public ResponseEntity<ApiResponse<Void>> notVerifiedEmailException(NotVerifiedEmailException ex) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.errorWithoutData(UserErrorCode.NOT_VERIFIED_EMAIL));
     }
 
 }

--- a/src/main/java/grep/neogul_coder/domain/users/exception/code/UserErrorCode.java
+++ b/src/main/java/grep/neogul_coder/domain/users/exception/code/UserErrorCode.java
@@ -12,7 +12,8 @@ public enum UserErrorCode implements ErrorCode {
     PASSWORD_UNCHECKED("U003", HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 다릅니다"),
     IS_DUPLICATED_MALI("U004", HttpStatus.BAD_REQUEST,"이미 존재하는 이메일입니다."),
     IS_DUPLICATED_NICKNAME("U005", HttpStatus.BAD_REQUEST,"이미 존재하는 닉네임입니다."),
-    UNACTIVATED_USER("U006", HttpStatus.BAD_REQUEST,"탈퇴된 회원입니다.");
+    UNACTIVATED_USER("U006", HttpStatus.BAD_REQUEST,"탈퇴된 회원입니다."),
+    NOT_VERIFIED_EMAIL("U007", HttpStatus.BAD_REQUEST, "메일 인증이 되지 않은 이메일입니다.");
 
 
     private final String code;

--- a/src/main/java/grep/neogul_coder/domain/users/exception/code/UserErrorCode.java
+++ b/src/main/java/grep/neogul_coder/domain/users/exception/code/UserErrorCode.java
@@ -11,7 +11,8 @@ public enum UserErrorCode implements ErrorCode {
     PASSWORD_MISMATCH("U002", HttpStatus.BAD_REQUEST, "비밀번호를 다시 확인해주세요."),
     PASSWORD_UNCHECKED("U003", HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 다릅니다"),
     IS_DUPLICATED_MALI("U004", HttpStatus.BAD_REQUEST,"이미 존재하는 이메일입니다."),
-    IS_DUPLICATED_NICKNAME("U005", HttpStatus.BAD_REQUEST,"이미 존재하는 닉네임입니다.");
+    IS_DUPLICATED_NICKNAME("U005", HttpStatus.BAD_REQUEST,"이미 존재하는 닉네임입니다."),
+    UNACTIVATED_USER("U006", HttpStatus.BAD_REQUEST,"탈퇴된 회원입니다.");
 
 
     private final String code;

--- a/src/main/java/grep/neogul_coder/domain/users/service/EmailVerificationService.java
+++ b/src/main/java/grep/neogul_coder/domain/users/service/EmailVerificationService.java
@@ -1,0 +1,74 @@
+package grep.neogul_coder.domain.users.service;
+
+import java.time.Duration;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService  {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final long CODE_TTL_SECONDS = 300;
+
+    public void sendVerificationEmail(String email) {
+        String code = generateRandomCode();
+
+        sendEmail(email,code);
+
+        redisTemplate.opsForValue().set(getRedisKey(email), code, Duration.ofSeconds(CODE_TTL_SECONDS));
+    }
+
+    public boolean verifyCode(String email, String inputCode) {
+        String redisKey = getRedisKey(email);
+        Object storedCode = redisTemplate.opsForValue().get(getRedisKey(email));
+
+
+        if (isValidCode(storedCode,inputCode)) {
+            redisTemplate.delete(redisKey);
+
+            redisTemplate.opsForValue().set(getVerifiedKey(email), "true", Duration.ofMinutes(10));
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isNotEmailVerified(String email) {
+        Object value = redisTemplate.opsForValue().get(getVerifiedKey(email));
+        return !"true".equals(value);
+    }
+
+    public void clearVerifiedStatus(String email) {
+        redisTemplate.delete(getVerifiedKey(email));
+    }
+
+    private void sendEmail(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[wibby] 이메일 인증 코드");
+        message.setText("인증 코드: " + code + "\n5분 안에 입력해주세요.");
+        mailSender.send(message);
+    }
+
+    private String generateRandomCode() {
+        return String.format("%06d", new Random().nextInt(1000000));
+    }
+
+    private String getRedisKey(String email) {
+        return "email_verification:" + email;
+    }
+
+    private String getVerifiedKey(String email) {
+        return "email_verified:" + email;
+    }
+
+    private boolean isValidCode(Object storedCode, String inputCode) {
+        return storedCode != null && storedCode.equals(inputCode);
+    }
+}

--- a/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
+++ b/src/main/java/grep/neogul_coder/domain/users/service/UserService.java
@@ -13,6 +13,7 @@ import grep.neogul_coder.domain.users.controller.dto.response.UserResponse;
 import grep.neogul_coder.domain.users.entity.User;
 import grep.neogul_coder.domain.users.exception.EmailDuplicationException;
 import grep.neogul_coder.domain.users.exception.NicknameDuplicatedException;
+import grep.neogul_coder.domain.users.exception.NotVerifiedEmailException;
 import grep.neogul_coder.domain.users.exception.PasswordNotMatchException;
 import grep.neogul_coder.domain.users.exception.UserNotFoundException;
 import grep.neogul_coder.domain.users.exception.code.UserErrorCode;
@@ -44,6 +45,7 @@ public class UserService {
     private final LinkService linkService;
     private final StudyManagementService studyManagementService;
     private final BuddyEnergyService buddyEnergyService;
+    private final EmailVerificationService verificationService;
 
     @Autowired(required = false)
     private GcpFileUploader gcpFileUploader;
@@ -69,6 +71,10 @@ public class UserService {
 
         duplicationCheck(request.getEmail(), request.getNickname());
 
+        if (verificationService.isNotEmailVerified(request.getEmail())) {
+            throw new NotVerifiedEmailException(UserErrorCode.NOT_VERIFIED_EMAIL);
+        }
+
         if (isNotMatchPasswordCheck(request.getPassword(), request.getPasswordCheck())) {
             throw new PasswordNotMatchException(UserErrorCode.PASSWORD_MISMATCH);
         }
@@ -78,8 +84,9 @@ public class UserService {
             User.UserInit(request.getEmail(), encodedPassword, request.getNickname()));
 
         User user = findUser(request.getEmail());
-
         initializeUserData(user.getId());
+
+        verificationService.clearVerifiedStatus(request.getEmail());
     }
 
     @Transactional

--- a/src/main/java/grep/neogul_coder/global/config/MailConfig.java
+++ b/src/main/java/grep/neogul_coder/global/config/MailConfig.java
@@ -1,0 +1,45 @@
+package grep.neogul_coder.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String email;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Bean
+    public JavaMailSender mailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(587);
+        mailSender.setUsername(email);
+        mailSender.setPassword(password);
+
+        Properties javaMailProperties = new Properties();
+        javaMailProperties.put("mail.transport.protocol", "smtp");
+        javaMailProperties.put("mail.smtp.auth", "true");
+        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");
+        javaMailProperties.put("mail.debug", "false");
+        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.gmail.com");
+        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");
+
+        mailSender.setJavaMailProperties(javaMailProperties);
+
+        return mailSender;
+    }
+
+}

--- a/src/main/java/grep/neogul_coder/global/config/security/SecurityConfig.java
+++ b/src/main/java/grep/neogul_coder/global/config/security/SecurityConfig.java
@@ -88,7 +88,9 @@ public class SecurityConfig {
                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
                         "/webjars/**",
                         "/favicon.ico",
-                        "/error").permitAll()
+                        "/error"
+                        ).permitAll()
+
                     .anyRequest().authenticated()
             )
             .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/grep/neogul_coder/global/response/ApiResponse.java
+++ b/src/main/java/grep/neogul_coder/global/response/ApiResponse.java
@@ -25,6 +25,10 @@ public class ApiResponse<T> {
         return ApiResponse.of(CommonCode.OK.getCode(), CommonCode.OK.getMessage(), data);
     }
 
+    public static <T> ApiResponse<T> success(String message) {
+        return ApiResponse.of(CommonCode.OK.getCode(), message, null);
+    }
+
     public static <T> ApiResponse<T> successWithCode(T data){
         return ApiResponse.of(CommonCode.OK.getCode(), CommonCode.OK.getMessage(), data);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
Closes #167 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

회원 가입 이전에 메일로 인증 번호를 발송하고 인증 완료된 메일에 한해서만 회원가입 가능하도록 하는 기능 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

구글 로그인 시점에 PR템플릿과 링크가 생성되지 않아서 생성하는 로직 추가
회원 가입 시 메일을 통한 인증을 해야만 가입 가능하도록 하는 기능 추가

메일 인증 코드 발송

<img width="1403" height="879" alt="image" src="https://github.com/user-attachments/assets/4c423f18-569b-4bf9-8150-7d2b3394bfbe" />

<img width="357" height="147" alt="image" src="https://github.com/user-attachments/assets/d75660c4-9483-4fba-954b-435dcc8fd6b6" />

-----------------

메일 인증 성공

<img width="1399" height="960" alt="image" src="https://github.com/user-attachments/assets/627061fa-7faf-4ee9-ab6e-2af417a9dee5" />

-----------------
메일 인증이 되지 않은 메일로 회원가입 요청 시

<img width="1402" height="1232" alt="image" src="https://github.com/user-attachments/assets/b17db269-705f-48ff-a03a-d0e99a055d3c" />
