### PR TITLE
[EA3-112] feature : 팀 캘린더 월 단위 일정 조회 API 추가

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarController.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarController.java
@@ -51,6 +51,17 @@ public class TeamCalendarController implements TeamCalendarSpecification {
         return ApiResponse.success(teamCalendarService.findByDate(studyId, parsedDate));
     }
 
+    // 특정 월(한 달 단위) 팀 일정 조회 API
+    @GetMapping("/month")
+    public ApiResponse<List<TeamCalendarResponse>> findByMonth(
+        @AuthenticationPrincipal(expression = "userId") Long userId,
+        @PathVariable("studyId") Long studyId,
+        @RequestParam int year,
+        @RequestParam int month
+    ) {
+        return ApiResponse.success(teamCalendarService.findByMonth(studyId, year, month));
+    }
+
     // 팀 일정 수정 API - 본인이 작성한 일정만 수정 가능
     @PutMapping("/{teamCalendarId}")
     public ApiResponse<Void> update(

--- a/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarSpecification.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/controller/TeamCalendarSpecification.java
@@ -42,6 +42,23 @@ public interface TeamCalendarSpecification {
         @RequestParam String date
     );
 
+    @Operation(
+        summary = "팀 일정 월 단위 조회",
+        description = "특정 팀의 특정 월(year, month)에 등록된 모든 일정을 조회합니다.\n\n" +
+            "예: `/api/teams/{studyId}/calendar/month?year=2025&month=7`"
+    )
+    ApiResponse<List<TeamCalendarResponse>> findByMonth(
+        @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
+        @Parameter(name = "studyId", description = "조회할 팀 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable("studyId") Long studyId,
+
+        @Parameter(name = "year", description = "조회할 연도 (예: 2025)", required = true, in = ParameterIn.QUERY)
+        @RequestParam int year,
+
+        @Parameter(name = "month", description = "조회할 월 (1~12)", required = true, in = ParameterIn.QUERY)
+        @RequestParam int month
+    );
+
 
     @Operation(
         summary = "팀 일정 생성",

--- a/src/main/java/grep/neogul_coder/domain/calender/repository/TeamCalendarQueryRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/repository/TeamCalendarQueryRepository.java
@@ -39,4 +39,20 @@ public class TeamCalendarQueryRepository {
             )
             .fetch();
     }
+
+    // 특정 월 구간 조회
+    public List<TeamCalendar> findByStudyIdAndMonth(Long studyId, LocalDateTime start, LocalDateTime end) {
+        QTeamCalendar tc = QTeamCalendar.teamCalendar;
+
+        return queryFactory
+            .selectFrom(tc)
+            .join(tc.calendar, calendar).fetchJoin()
+            .where(
+                tc.studyId.eq(studyId),
+                tc.activated.eq(true),
+                calendar.scheduledStart.lt(end),
+                calendar.scheduledEnd.goe(start)
+            )
+            .fetch();
+    }
 }

--- a/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
+++ b/src/main/java/grep/neogul_coder/domain/calender/service/TeamCalendarService.java
@@ -58,6 +58,21 @@ public class TeamCalendarService {
             .toList();
     }
 
+    // 특정 월(한 달 단위) 조회
+    public List<TeamCalendarResponse> findByMonth(Long studyId, int year, int month) {
+        LocalDate startOfMonth = LocalDate.of(year, month, 1);
+        LocalDateTime start = startOfMonth.atStartOfDay();
+        LocalDateTime end = startOfMonth.plusMonths(1).atStartOfDay();
+
+        return teamCalendarQueryRepository
+            .findByStudyIdAndMonth(studyId, start, end).stream()
+            .map(tc -> {
+                User user = userService.get(tc.getUserId());
+                return TeamCalendarResponse.from(tc, user);
+            })
+            .toList();
+    }
+
     @Transactional
     public Long create(Long studyId, Long userId, TeamCalendarRequest request) {
         validateRequest(request);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
-closed #55 

## 📌 과제 설명 
- 팀 캘린더 API 기능 고도화 및 월 단위 일정 조회 기능 추가.
## 👩‍💻 요구 사항과 구현 내용 
## TeamCalendarQueryRepository
- findByStudyIdAndMonth(Long studyId, LocalDateTime start, LocalDateTime end) 메서드 추가.

## TeamCalendarService
- findByMonth(Long studyId, int year, int month) 메서드 추가.

## TeamCalendarController
- /api/teams/{studyId}/calendar/month?year=YYYY&month=MM 엔드포인트 추가.

## TeamCalendarSpecification
- 월 단위 조회 API 인터페이스 정의.

## ✅ 피드백 반영사항 
<img width="1648" height="702" alt="image" src="https://github.com/user-attachments/assets/63970814-c86e-49a0-9a89-4929c449c4aa" />
<img width="668" height="352" alt="image" src="https://github.com/user-attachments/assets/3c7f6e15-7f21-4d2d-87c5-1751619239a3" />

