### PR TITLE
[EA3-113] feature : 버디에너지 스터디 + 1/ 리더 + 2 점 구현

### DIFF
--- a/src/main/java/grep/neogul_coder/NeogulCoderApplication.java
+++ b/src/main/java/grep/neogul_coder/NeogulCoderApplication.java
@@ -5,7 +5,9 @@ import java.util.TimeZone;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class NeogulCoderApplication {
 

--- a/src/main/java/grep/neogul_coder/domain/buddy/service/BuddyEnergyService.java
+++ b/src/main/java/grep/neogul_coder/domain/buddy/service/BuddyEnergyService.java
@@ -45,6 +45,27 @@ public class BuddyEnergyService {
         return BuddyEnergyResponse.from(energy);
     }
 
+    // 스터디 종료 시 +1, 리더면 +2
+    @Transactional
+    public BuddyEnergyResponse updateEnergyByStudy(Long userId, boolean isLeader) {
+        BuddyEnergy energy = buddyEnergyRepository.findByUserId(userId)
+            .orElseThrow(() -> new BuddyEnergyNotFoundException(BUDDY_ENERGY_NOT_FOUND));
+
+        int points = BuddyEnergyReason.STUDY_DONE.getPoint();
+        BuddyEnergyReason reason = BuddyEnergyReason.STUDY_DONE;
+
+        if (isLeader) {
+            points += BuddyEnergyReason.TEAM_LEADER_BONUS.getPoint();
+            reason = BuddyEnergyReason.TEAM_LEADER_BONUS;
+        }
+
+        energy.updateLevel(energy.getLevel() + points);
+        buddyEnergyLogRepository.save(BuddyLog.of(energy, reason));
+        buddyEnergyRepository.save(energy);
+
+        return BuddyEnergyResponse.from(energy);
+    }
+
     // 회원가입 시 기본 에너지 생성
     @Transactional
     public BuddyEnergyResponse createDefaultEnergy(Long userId) {

--- a/src/main/java/grep/neogul_coder/domain/study/service/StudySchedulerService.java
+++ b/src/main/java/grep/neogul_coder/domain/study/service/StudySchedulerService.java
@@ -31,7 +31,7 @@ public class StudySchedulerService {
         return studyRepository.findStudiesEndingIn7Days(endDateStart, endDateEnd);
     }
 
-    @Scheduled(fixedRate = 5000)
+    @Scheduled(cron = "0 0 * * * *")
     @Transactional
     public void finalizeStudies() {
         LocalDateTime now = LocalDateTime.now();


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
#56 

## 📌 과제 설명
스터디 종료 시 + 1점, 리더 보너스 + 2 점을 버디에너지에 반영 하였습니다
## 👩‍💻 요구 사항과 구현 내용 
## BuddyEnergy 도메인
- BuddyEnergyService에 updateEnergyByReview(), updateEnergyByStudy() 메서드 구현
- 리뷰 작성 시: 긍정 리뷰(+1), 부정 리뷰(-1) 자동 반영.
- 스터디 종료 시: 멤버 +1점, 스터디 리더는 추가 보너스(+1점 → 총 +2점) 적용.

## StudySchedulerService
- 스케줄러 기반 스터디 자동 종료 처리
- @Scheduled(fixedRate = 5000)로 테스트 환경에서 5초마다 종료 상태 확인.
- 현재는 성능 부담을 방지해 @Scheduled(cron = "0 0 * * * *")로 매 시 정각마다 종료 상태 확인.
- 종료된 스터디의 멤버를 조회 후 buddyEnergyService.updateEnergyByStudy() 호출.
- 스터디 finished 상태 갱신.

## ✅ 피드백 반영사항  
<img width="783" height="473" alt="image" src="https://github.com/user-attachments/assets/03c0fd35-1225-4348-8bbf-d5d809f06a4d" />

<img width="341" height="201" alt="image" src="https://github.com/user-attachments/assets/8e33fbe6-1c01-43e4-be92-a5cf26737126" />

<img width="797" height="263" alt="image" src="https://github.com/user-attachments/assets/c9288b45-25a7-442b-8654-b2b03658ef4a" />

<img width="872" height="430" alt="image" src="https://github.com/user-attachments/assets/7b3916c4-261b-4a73-b914-473e89122fca" />
