### PR TITLE
[EA3-134] refactor : 스터디 모임 일정 조율 -  스터디원/팀장 여부 및 투표 시간 검증 로직 개선

### DIFF
--- a/src/main/java/grep/neogul_coder/domain/timevote/controller/TimeVoteController.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/controller/TimeVoteController.java
@@ -69,7 +69,7 @@ public class TimeVoteController implements TimeVoteSpecification {
       @RequestBody @Valid TimeVoteUpdateRequest request,
       @AuthenticationPrincipal Principal userDetails
   ) {
-    TimeVoteResponse response = timeVoteService.updateVote(request, studyId, userDetails.getUserId());
+    TimeVoteResponse response = timeVoteService.updateVotes(request, studyId, userDetails.getUserId());
     return ApiResponse.success(response);
   }
 

--- a/src/main/java/grep/neogul_coder/domain/timevote/controller/TimeVoteController.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/controller/TimeVoteController.java
@@ -79,7 +79,7 @@ public class TimeVoteController implements TimeVoteSpecification {
       @AuthenticationPrincipal Principal userDetails
   ) {
     timeVoteService.deleteAllVotes(studyId, userDetails.getUserId());
-    return ApiResponse.noContent();
+    return ApiResponse.success("성공적으로 투표를 삭제했습니다.");
   }
 
   @GetMapping("/periods/submissions")

--- a/src/main/java/grep/neogul_coder/domain/timevote/dto/request/TimeVoteCreateRequest.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/dto/request/TimeVoteCreateRequest.java
@@ -21,8 +21,7 @@ public class TimeVoteCreateRequest {
   )
   private List<LocalDateTime> timeSlots;
 
-  private TimeVoteCreateRequest() {
-  }
+  private TimeVoteCreateRequest() {}
 
   @Builder
   private TimeVoteCreateRequest(List<LocalDateTime> timeSlots) {

--- a/src/main/java/grep/neogul_coder/domain/timevote/exception/code/TimeVoteErrorCode.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/exception/code/TimeVoteErrorCode.java
@@ -13,7 +13,10 @@ public enum TimeVoteErrorCode implements ErrorCode {
   TIME_VOTE_PERIOD_NOT_FOUND("T004", HttpStatus.NOT_FOUND, "해당 스터디에 대한 투표 기간이 존재하지 않습니다."),
   INVALID_TIME_VOTE_PERIOD("T005", HttpStatus.BAD_REQUEST, "모일 일정 조율 기간은 최대 7일까지 설정할 수 있습니다."),
   TIME_VOTE_ALREADY_SUBMITTED("T006", HttpStatus.CONFLICT, "이미 투표를 제출했습니다. PUT 요청으로 기존의 제출한 투표를 수정하세요."),
-  TIME_VOTE_OUT_OF_RANGE("T007", HttpStatus.BAD_REQUEST, "선택한 시간이 투표 기간을 벗어났습니다.");
+  TIME_VOTE_OUT_OF_RANGE("T007", HttpStatus.BAD_REQUEST, "선택한 시간이 투표 기간을 벗어났습니다."),
+  TIME_VOTE_NOT_FOUND("T008", HttpStatus.BAD_REQUEST, "시간 투표 이력이 존재하지 않습니다."),
+  TIME_VOTE_STAT_CONFLICT("T009", HttpStatus.CONFLICT, "투표 통계 저장 중 충돌이 발생했습니다. 다시 시도해주세요."),
+  TIME_VOTE_THREAD_INTERRUPTED("T010", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 스레드 오류가 발생했습니다. 다시 시도해주세요.");
 
   private final String code;
   private final HttpStatus status;

--- a/src/main/java/grep/neogul_coder/domain/timevote/exception/code/TimeVoteErrorCode.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/exception/code/TimeVoteErrorCode.java
@@ -7,12 +7,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum TimeVoteErrorCode implements ErrorCode {
 
-  FORBIDDEN_TIME_VOTE_CREATE("T001", HttpStatus.BAD_REQUEST, "투표 생성은 스터디장만 가능합니다."),
-  STUDY_NOT_FOUND("T002", HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
-  STUDY_MEMBER_NOT_FOUND("T003", HttpStatus.NOT_FOUND, "스터디 멤버가 아닙니다."),
+  FORBIDDEN_TIME_VOTE_CREATE("T001", HttpStatus.BAD_REQUEST, "모임 일정 조율 투표 생성은 스터디장만 가능합니다."),
+  STUDY_NOT_FOUND("T002", HttpStatus.NOT_FOUND, "해당 스터디를 찾을 수 없습니다."),
+  STUDY_MEMBER_NOT_FOUND("T003", HttpStatus.NOT_FOUND, "해당 스터디의 멤버가 아닙니다."),
   TIME_VOTE_PERIOD_NOT_FOUND("T004", HttpStatus.NOT_FOUND, "해당 스터디에 대한 투표 기간이 존재하지 않습니다."),
-  INVALID_TIME_VOTE_PERIOD("T005", HttpStatus.BAD_REQUEST, "모일 일정 조율 기간은 최대 7일까지 설정할 수 있습니다.");
-
+  INVALID_TIME_VOTE_PERIOD("T005", HttpStatus.BAD_REQUEST, "모일 일정 조율 기간은 최대 7일까지 설정할 수 있습니다."),
+  TIME_VOTE_ALREADY_SUBMITTED("T006", HttpStatus.CONFLICT, "이미 투표를 제출했습니다. PUT 요청으로 기존의 제출한 투표를 수정하세요."),
+  TIME_VOTE_OUT_OF_RANGE("T007", HttpStatus.BAD_REQUEST, "선택한 시간이 투표 기간을 벗어났습니다.");
 
   private final String code;
   private final HttpStatus status;

--- a/src/main/java/grep/neogul_coder/domain/timevote/repository/TimeVoteRepository.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/repository/TimeVoteRepository.java
@@ -12,4 +12,6 @@ public interface TimeVoteRepository extends JpaRepository<TimeVote, Long> {
   List<TimeVote> findByPeriodAndStudyMemberId(TimeVotePeriod period, Long userId);
 
   void deleteAllByPeriodAndStudyMemberId(TimeVotePeriod period, Long studyMemberId);
+
+  boolean existsByPeriodAndStudyMemberId(TimeVotePeriod period, Long studyMemberId);
 }

--- a/src/main/java/grep/neogul_coder/domain/timevote/service/TimeVotePeriodService.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/service/TimeVotePeriodService.java
@@ -3,6 +3,7 @@ package grep.neogul_coder.domain.timevote.service;
 import static grep.neogul_coder.domain.timevote.exception.code.TimeVoteErrorCode.*;
 
 import grep.neogul_coder.domain.study.Study;
+import grep.neogul_coder.domain.study.StudyMember;
 import grep.neogul_coder.domain.study.enums.StudyMemberRole;
 import grep.neogul_coder.domain.study.repository.StudyMemberRepository;
 import grep.neogul_coder.domain.study.repository.StudyRepository;
@@ -32,7 +33,8 @@ public class TimeVotePeriodService {
   private final StudyMemberRepository studyMemberRepository;
 
   public TimeVotePeriod createTimeVotePeriodAndReturn(TimeVotePeriodCreateRequest request, Long studyId, Long userId) {
-    validateStudyLeader(studyId, userId);
+    StudyMember studyMember = getValidStudyMember(studyId, userId);
+    validateStudyLeader(studyMember);
     validateMaxPeriod(request.getStartDate(), request.getEndDate());
 
     if (timeVotePeriodRepository.existsByStudyId(studyId)) {
@@ -41,10 +43,8 @@ public class TimeVotePeriodService {
 
     TimeVotePeriod savedPeriod = timeVotePeriodRepository.save(request.toEntity(studyId));
 
-    StudyMemberRole role = getStudyMemberRole(studyId, userId);
-
     log.info("📝 TimeVotePeriod 생성됨 - studyId: {}, userId: {}, role: {}, periodId: {}, start: {}, end: {}",
-        studyId, userId, role, savedPeriod.getPeriodId(), savedPeriod.getStartDate(), savedPeriod.getEndDate());
+        studyId, userId, studyMember.getRole(), savedPeriod.getPeriodId(), savedPeriod.getStartDate(), savedPeriod.getEndDate());
 
     return savedPeriod;
   }
@@ -58,27 +58,23 @@ public class TimeVotePeriodService {
     timeVotePeriodRepository.deleteAllByStudyId(studyId);
   }
 
+  // 검증 로직
+  private StudyMember getValidStudyMember(Long studyId, Long userId) {
+    return studyMemberRepository.findByStudyIdAndUserIdAndActivatedTrue(studyId, userId)
+        .orElseThrow(() -> new BusinessException(STUDY_MEMBER_NOT_FOUND));
+  }
+
+  private void validateStudyLeader(StudyMember member){
+    if(member.getRole() != StudyMemberRole.LEADER) {
+      throw new BusinessException(FORBIDDEN_TIME_VOTE_CREATE);
+    }
+  }
+
   private void validateMaxPeriod(LocalDateTime startDate, LocalDateTime endDate) {
     Long days = Duration.between(startDate, endDate).toDays();
 
     if(days > 6) {
       throw new BusinessException(INVALID_TIME_VOTE_PERIOD);
     }
-  }
-
-  private void validateStudyLeader(Long studyId, Long userId) {
-    boolean isLeader = studyMemberRepository.existsByStudyIdAndUserIdAndRoleAndActivatedTrue(
-        studyId, userId, StudyMemberRole.LEADER
-    );
-
-    if (!isLeader) {
-      throw new BusinessException(FORBIDDEN_TIME_VOTE_CREATE);
-    }
-  }
-
-  private StudyMemberRole getStudyMemberRole(Long studyId, Long userId) {
-    return studyMemberRepository.findByStudyIdAndUserIdAndActivatedTrue(studyId, userId)
-        .map(sm -> sm.getRole())
-        .orElseThrow(() -> new BusinessException(STUDY_MEMBER_NOT_FOUND));
   }
 }

--- a/src/main/java/grep/neogul_coder/domain/timevote/service/TimeVoteService.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/service/TimeVoteService.java
@@ -61,6 +61,7 @@ public class TimeVoteService {
     StudyMember studyMember = getValidStudyMember(studyId, userId);
     TimeVotePeriod period = getValidTimeVotePeriod(studyId);
 
+    validateAlreadySubmitted(period, studyMember.getId());
     validateVoteWithinPeriod(period, request.getTimeSlots());
 
     timeVoteRepository.deleteAllByPeriodAndStudyMemberId(period, studyMember.getId());
@@ -114,6 +115,13 @@ public class TimeVoteService {
     boolean alreadySubmitted = timeVoteRepository.existsByPeriodAndStudyMemberId(period, studyMemberId);
     if (alreadySubmitted) {
       throw new BusinessException(TIME_VOTE_ALREADY_SUBMITTED);
+    }
+  }
+
+  private void validateAlreadySubmitted(TimeVotePeriod period, Long studyMemberId) {
+    boolean alreadySubmitted = timeVoteRepository.existsByPeriodAndStudyMemberId(period, studyMemberId);
+    if (!alreadySubmitted) {
+      throw new BusinessException(TIME_VOTE_NOT_FOUND);
     }
   }
 }

--- a/src/main/java/grep/neogul_coder/domain/timevote/service/TimeVoteService.java
+++ b/src/main/java/grep/neogul_coder/domain/timevote/service/TimeVoteService.java
@@ -57,7 +57,7 @@ public class TimeVoteService {
     return TimeVoteResponse.from(studyMember.getId(), saved);
   }
 
-  public TimeVoteResponse updateVote(TimeVoteUpdateRequest request, Long studyId, Long userId) {
+  public TimeVoteResponse updateVotes(TimeVoteUpdateRequest request, Long studyId, Long userId) {
     StudyMember studyMember = getValidStudyMember(studyId, userId);
     TimeVotePeriod period = getValidTimeVotePeriod(studyId);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
References #92 

## 📌 과제 설명
스터디 일정 조율 기능 전반에 걸쳐 검증 흐름의 명확화, 예외 처리 개선, 응답 메시지 개선을 진행하였습니다.

## 👩‍💻 요구 사항과 구현 내용
🔹 `TimeVotePeriodService`
1. 팀 리더 여부만 검증하던 기존 로직을 → 스터디원인지 먼저 검증한 후 팀 리더인지 확인하는 방식으로 개선
2. 모임 일정 조율 기간은 최대 7일까지 허용되도록 검증 로직 추가

🔹 `TimeVoteService`

1. `submitVotes`, `updateVotes`, `getMyVotes` 등에서  
   → 기존: 투표 기간 검증 → 스터디원 검증
   → 변경: 스터디원 검증 → 투표 기간 검증 흐름으로 일관성 있게 수정
2. `submitVotes`에서 이미 제출된 투표는 다시 제출하지 못하도록 예외 처리 추가
3. `submitVotes`, `updateVotes` 내에서 투표 시간대가 설정된 기간을 벗어날 경우 예외 발생하도록 검증 로직 추가
4. `updateVote` → `updateVotes`로 복수형 메서드명으로 변경하여 의미 명확화
+ `updateVotes`에서 기존에 제출한 이력이 없으면 제출하지 못하도록 예외 처리 추가

🔹 공통
- 검증용 에러 코드 추가 (`TIME_VOTE_OUT_OF_RANGE`, 등)
- 삭제 API 응답을 `noContent()` → `success()`로 변경하여 프론트엔드에서의 일관된 메시지 처리 가능하도록 개선

## ✅ PR 포인트 & 궁금한 점 
<img width="888" height="389" alt="스크린샷 2025-07-23 16 45 28" src="https://github.com/user-attachments/assets/1fa99644-8f25-44d8-95a3-9736b3e8ee4c" />
<img width="883" height="410" alt="스크린샷 2025-07-23 16 45 52" src="https://github.com/user-attachments/assets/276a6ec8-c51d-4b01-94d7-4b58a2eb847b" />
<img width="885" height="355" alt="스크린샷 2025-07-23 16 47 52" src="https://github.com/user-attachments/assets/09010557-7315-4914-8ee0-2dd2a05631b7" />
<img width="882" height="378" alt="스크린샷 2025-07-23 16 48 15" src="https://github.com/user-attachments/assets/9c93c9fb-f43f-4777-81e6-84fdbaca452a" />
<img width="889" height="401" alt="스크린샷 2025-07-23 16 48 42" src="https://github.com/user-attachments/assets/ad8c0645-ebb3-4a60-afd5-9f826d494d6c" />
