### PR TITLE
[EA3-111] refactor : 그룹 채팅 로직 studyId 기반으로 전면 리팩토링

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestController.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestController.java
@@ -16,15 +16,15 @@ public class GroupChatRestController implements GroupChatRestSpecification {
 
     // 과거 채팅 메시지 페이징 조회 (무한 스크롤용)
     @Override
-    @GetMapping("/room/{roomId}/messages")
+    @GetMapping("/study/{studyId}/messages")
     public ApiResponse<PageResponse<GroupChatMessageResponseDto>> getMessages(
-        @PathVariable("roomId") Long roomId,
+        @PathVariable("studyId") Long studyId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size
     ) {
         // 서비스에서 페이징된 메시지 조회
         PageResponse<GroupChatMessageResponseDto> pageResponse =
-            groupChatService.getMessages(roomId, page, size);
+            groupChatService.getMessages(studyId, page, size);
 
         return ApiResponse.success(pageResponse);
     }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestSpecification.java
@@ -16,20 +16,20 @@ public interface GroupChatRestSpecification {
         summary = "채팅 메시지 페이징 조회",
         description = """
         이 API는 **채팅방의 과거 메시지**를 페이지 단위로 가져오는 용도입니다.  
-        WebSocket의 실시간 수신(`/sub/chat/room/{roomId}`)과는 별개로,  
+        WebSocket의 실시간 수신(`/sub/chat/study/{studyId}`)과는 별개로,  
         채팅방에 입장할 때 이전 대화 기록을 불러오는 데 사용됩니다.
         
         ---
         
         **프론트엔드 연동 흐름 (권장 방식)**:
-        1. **채팅방 입장 시** → `GET /api/chat/room/{roomId}/messages?page=0&size=20` 호출해 최신 메시지 20개 로드  
+        1. **채팅방 입장 시** → `GET /api/chat/study/{studyId}/messages?page=0&size=20` 호출해 최신 메시지 20개 로드  
         2. **스크롤 위로 올릴 때** → `page=1`, `page=2` ... 순차적으로 과거 메시지를 추가 로딩 (무한 스크롤)  
-        3. **동시에** → WebSocket(`wss://wibby.cedartodo.uk/ws-stomp`) 연결 후 `/sub/chat/room/{roomId}`를 **구독**해 실시간 메시지 수신  
+        3. **동시에** → WebSocket(`wss://wibby.cedartodo.uk/ws-stomp`) 연결 후 `/sub/chat/study/{studyId}`를 **구독**해 실시간 메시지 수신  
         
         ---
         
         **파라미터 설명**:
-        - `roomId`: 채팅방 ID  
+        - `studyId`: 스터디 ID  
         - `page`: 페이지 번호 (0부터 시작, 0 = 최신 메시지 20개)  
         - `size`: 한 페이지당 메시지 수 (기본값 20)  
         - 메시지는 **오래된 순(오름차순)**으로 반환됩니다.
@@ -45,7 +45,7 @@ public interface GroupChatRestSpecification {
         
         **예시 요청 URL**:
         ```
-        /api/chat/room/1/messages?page=0&size=20
+        /api/chat/study/1/messages?page=0&size=20
         ```
         
         **예시 응답**:
@@ -56,7 +56,7 @@ public interface GroupChatRestSpecification {
             "content": [
               {
                 "id": 101,
-                "roomId": 1,
+                "studyId": 1,
                 "senderId": 10,
                 "senderNickname": "유강현",
                 "profileImageUrl": "https://example.com/profile.jpg",
@@ -74,8 +74,8 @@ public interface GroupChatRestSpecification {
     )
 
     ApiResponse<PageResponse<GroupChatMessageResponseDto>> getMessages(
-        @Parameter(description = "채팅방 ID", example = "1")
-        @PathVariable("roomId") Long roomId,
+        @Parameter(description = "스터디 ID", example = "1")
+        @PathVariable("studyId") Long studyId,
 
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
         @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerController.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerController.java
@@ -20,9 +20,9 @@ public class GroupChatSwaggerController implements GroupChatSwaggerSpecification
     }
 
 
-    @GetMapping("/sub/chat/room/{roomId}")
+    @GetMapping("/sub/chat/study/{studyId}")
     @Override
-    public ApiResponse<List<GroupChatSwaggerResponse>> getMessages(@PathVariable Long roomId) {
+    public ApiResponse<List<GroupChatSwaggerResponse>> getMessages(@PathVariable Long studyId) {
         List<GroupChatSwaggerResponse> messages = List.of(
             new GroupChatSwaggerResponse(),
             new GroupChatSwaggerResponse()

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerSpecification.java
@@ -24,7 +24,7 @@ public interface GroupChatSwaggerSpecification {
         **예시 Request JSON**
         ```json
         {
-          "roomId": 1,
+          "studyId": 1,
           "senderId": 10,
           "message": "안녕하세요!"
         }
@@ -43,16 +43,16 @@ public interface GroupChatSwaggerSpecification {
         - 먼저 `wss://wibby.cedartodo.uk/ws-stomp` 엔드포인트로 STOMP 연결을 맺습니다.
 
         **2. 메시지 구독**
-        - 연결 후 `/sub/chat/room/{roomId}` 경로를 구독(subscribe)하면 해당 채팅방의 새로운 메시지를 실시간으로 수신할 수 있습니다.
+        - 연결 후 `/sub/chat/study/{studyId}` 경로를 구독(subscribe)하면 해당 채팅방의 새로운 메시지를 실시간으로 수신할 수 있습니다.
 
         **예시 Subscribe 경로**
-        `/sub/chat/room/1`
+        `/sub/chat/study/1`
 
         **예시 수신 데이터(JSON)**
         ```json
         {
           "id": 101,
-          "roomId": 1,
+          "studyId": 1,
           "senderId": 10,
           "senderNickname": "유강현",
           "profileImageUrl": "https://example.com/profile.jpg",
@@ -64,5 +64,5 @@ public interface GroupChatSwaggerSpecification {
         ** Swagger에서는 WebSocket 구독을 테스트할 수 없으며,
         이 문서는 프론트엔드 구현 참고용입니다.**
         """)
-    ApiResponse<List<GroupChatSwaggerResponse>> getMessages(Long roomId);
+    ApiResponse<List<GroupChatSwaggerResponse>> getMessages(Long studyId);
 }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatWebSocketController.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatWebSocketController.java
@@ -28,17 +28,17 @@ public class GroupChatWebSocketController {
     // 클라이언트가 /pub/chat/message 로 보낼 때 처리됨
     @MessageMapping("/chat/message")
     public void handleMessage(GroupChatMessageRequestDto requestDto) {
-        log.info("[웹소켓] 새 메시지 수신 - 채팅방: {}, 보낸 사람: {}, 내용: {}",
-            requestDto.getRoomId(), requestDto.getSenderId(), requestDto.getMessage());
+        log.info("[웹소켓] 새 메시지 수신 - 스터디: {}, 보낸 사람: {}, 내용: {}",
+            requestDto.getStudyId(), requestDto.getSenderId(), requestDto.getMessage());
 
         // 메시지를 DB에 저장하고, 응답 DTO 생성
         GroupChatMessageResponseDto responseDto = groupChatService.saveMessage(requestDto);
 
-        // 구독 중인 클라이언트에게 메시지 전송 (채팅방 구분)
-        // 클라이언트는 /sub/chat/room/{roomId} 구독 중이어야 실시간으로 수신 가능
-        log.info("[웹소켓] 채팅방 {} 구독자에게 메시지 전송 완료", requestDto.getRoomId());
+        // 구독 중인 클라이언트에게 메시지 전송 (스터디 구분)
+        // 클라이언트는 /sub/chat/study/{studyId} 구독 중이어야 실시간으로 수신 가능
+        log.info("[웹소켓] 스터디 {} 구독자에게 메시지 전송 완료", requestDto.getStudyId());
         messagingTemplate.convertAndSend(
-            "/sub/chat/room/" + requestDto.getRoomId(), // 메시지를 받을 대상
+            "/sub/chat/study/" + requestDto.getStudyId(), // 메시지를 받을 대상
             responseDto                                          // 클라이언트에 전달할 응답 메시지 DTO
         );
     }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/requset/GroupChatMessageRequestDto.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/requset/GroupChatMessageRequestDto.java
@@ -9,14 +9,14 @@ import lombok.Getter;
 @Hidden
 @Getter
 public class GroupChatMessageRequestDto {
-    private Long roomId;
+    private Long studyId;
     private Long senderId;
     private String message;
 
     public GroupChatMessageRequestDto() {}
 
-    public GroupChatMessageRequestDto(Long roomId, Long senderId, String message) {
-        this.roomId = roomId;
+    public GroupChatMessageRequestDto(Long studyId, Long senderId, String message) {
+        this.studyId = studyId;
         this.senderId = senderId;
         this.message = message;
     }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/requset/GroupChatSwaggerRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/requset/GroupChatSwaggerRequest.java
@@ -10,8 +10,8 @@ public class GroupChatSwaggerRequest {
     @Schema(description = "보낸 사람 ID", example = "456")
     private Long senderId;
 
-    @Schema(description = "채팅방 ID", example = "100")
-    private Long roomId;
+    @Schema(description = "스터디 ID", example = "100")
+    private Long studyId;
 
     @Schema(description = "보낼 메시지", example = "안녕하세요!")
     private String message;

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/response/GroupChatMessageResponseDto.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/response/GroupChatMessageResponseDto.java
@@ -11,18 +11,18 @@ import lombok.Getter;
 public class GroupChatMessageResponseDto {
 
     private Long id;                    // 메시지 고유 ID
-    private Long roomId;                // 채팅방 ID
+    private Long studyId;                // 채팅방 ID
     private Long senderId;              // 보낸 사람 ID
     private String senderNickname;      // 보낸 사람 닉네임
     private String profileImageUrl;     // 프로필 이미지 URL
     private String message;             // 메시지 내용
     private LocalDateTime sentAt;       // 보낸 시간
 
-    private GroupChatMessageResponseDto(Long id, Long roomId, Long senderId,
+    private GroupChatMessageResponseDto(Long id, Long studyId, Long senderId,
         String senderNickname, String profileImageUrl,
         String message, LocalDateTime sentAt) {
         this.id = id;
-        this.roomId = roomId;
+        this.studyId = studyId;
         this.senderId = senderId;
         this.senderNickname = senderNickname;
         this.profileImageUrl = profileImageUrl;
@@ -33,7 +33,7 @@ public class GroupChatMessageResponseDto {
     public static GroupChatMessageResponseDto from(GroupChatMessage message, User sender) {
         return new GroupChatMessageResponseDto(
             message.getMessageId(),
-            message.getGroupChatRoom().getRoomId(),
+            message.getGroupChatRoom().getStudyId(),
             sender.getId(),
             sender.getNickname(),
             sender.getProfileImageUrl(),

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/response/GroupChatSwaggerResponse.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/response/GroupChatSwaggerResponse.java
@@ -20,8 +20,8 @@ public class GroupChatSwaggerResponse {
     @Schema(description = "프로필 이미지 URL", example = "https://ganghyeon.jpg")
     private String profileImageUrl;
 
-    @Schema(description = "채팅방 ID", example = "100")
-    private Long roomId;
+    @Schema(description = "스터디 ID", example = "100")
+    private Long studyId;
 
     @Schema(description = "보낸 메시지", example = "안녕하세요!")
     private String message;

--- a/src/main/java/grep/neogulcoder/domain/groupchat/service/GroupChatService.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/service/GroupChatService.java
@@ -32,21 +32,20 @@ public class GroupChatService {
 
     @Transactional
     public GroupChatMessageResponseDto saveMessage(GroupChatMessageRequestDto requestDto) {
-        log.info("[서비스] 메시지 저장 시작 - 채팅방: {}, 보낸 사람: {}",
-            requestDto.getRoomId(), requestDto.getSenderId());
+        log.info("[서비스] 메시지 저장 시작 - 스터디: {}, 보낸 사람: {}",
+            requestDto.getStudyId(), requestDto.getSenderId());
 
         // 채팅방 존재 여부 확인
-        GroupChatRoom room = roomRepository.findById(requestDto.getRoomId())
+        GroupChatRoom room = roomRepository.findByStudyId(requestDto.getStudyId())
             .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
         // 메시지 발신자(사용자) 정보 조회
         User sender = userRepository.findById(requestDto.getSenderId())
             .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
 
-        log.info("[서비스] 보낸 사람 '{}' 검증 완료 (roomId={})", sender.getNickname(), room.getRoomId());
+        log.info("[서비스] 보낸 사람 '{}' 검증 완료 (studyId={})", sender.getNickname(), room.getStudyId());
 
         // 스터디 참가자 검증 로직 추가
-        Long studyId = room.getStudyId();
-        boolean isParticipant = studyMemberRepository.existsByStudyIdAndUserId(studyId, sender.getId());
+        boolean isParticipant = studyMemberRepository.existsByStudyIdAndUserId(requestDto.getStudyId(), sender.getId());
         if (!isParticipant) {
             throw new IllegalArgumentException("해당 스터디에 참가한 사용자만 채팅할 수 있습니다.");
         }
@@ -56,20 +55,23 @@ public class GroupChatService {
         // 메시지 저장
         messageRepository.save(message);
 
-        log.info("[서비스] 메시지 저장 완료 - 메시지ID: {}, 채팅방: {}, 시간: {}",
-            message.getMessageId(), room.getRoomId(), message.getSentAt());
+        log.info("[서비스] 메시지 저장 완료 - 메시지ID: {}, 스터디: {}, 시간: {}",
+            message.getMessageId(), room.getStudyId(), message.getSentAt());
 
         // 응답 dto 생성
         return GroupChatMessageResponseDto.from(message, sender);
     }
 
     // 과거 채팅 메시지 페이징 조회 (무한 스크롤용)
-    public PageResponse<GroupChatMessageResponseDto> getMessages(Long roomId, int page, int size) {
+    public PageResponse<GroupChatMessageResponseDto> getMessages(Long studyId, int page, int size) {
+        GroupChatRoom room = roomRepository.findByStudyId(studyId)
+            .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+
         // 오래된 메시지부터 조회되도록 정렬 기준을 ASC로 설정
         Pageable pageable = PageRequest.of(page, size, Sort.by("sentAt").ascending());
 
         // JPQL 쿼리 메서드 기반 조회
-        Page<GroupChatMessage> messages = messageRepository.findMessagesByRoomIdAsc(roomId, pageable);
+        Page<GroupChatMessage> messages = messageRepository.findMessagesByRoomIdAsc(room.getRoomId(), pageable);
 
         // 응답 DTO로 변환
         Page<GroupChatMessageResponseDto> messagePage = messages.map(message -> {
@@ -81,7 +83,7 @@ public class GroupChatService {
 
         // PageResponse로 감싸서 반환
         return new PageResponse<>(
-            "/api/chat/room/" + roomId + "/messages",
+            "/api/chat/study/" + studyId + "/messages",
             messagePage,
             5 // 페이지 버튼 개수
         );

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -32,7 +32,7 @@ INSERT INTO study_member (study_id, user_id, role, participated, activated) VALU
 INSERT INTO study_member (study_id, user_id, role, participated, activated) VALUES (3, 2, 'LEADER', FALSE, TRUE);
 INSERT INTO study_member (study_id, user_id, role, participated, activated) VALUES (3, 1, 'MEMBER', FALSE, TRUE);
 INSERT INTO study_member (study_id, user_id, role, participated, activated) VALUES (6, 7, 'LEADER', FALSE, TRUE);
-INSERT INTO study_member (study_id, user_id, role, participated, activated) VALUES (6, 8, 'MEMBER', FALSE, TRUE);
+INSERT INTO study_member (study_id, user_id, role, participated, activated) VALUES (5, 8, 'MEMBER', FALSE, TRUE);
 INSERT INTO study_member (study_id, user_id, role, participated, activated) VALUES (6, 9, 'MEMBER', FALSE, TRUE);
 
 INSERT INTO recruitment_post (user_id, study_id, subject, content, recruitment_count, expired_date, status, activated) VALUES (3, 1, '자바 스터디 모집', '이펙티브 자바 공부하실분 구해요!!', 3, '2025-04-19', 'COMPLETE', true);
@@ -156,7 +156,7 @@ INSERT INTO attendance (study_id, user_id, attendance_date, activated) VALUES (2
 INSERT INTO attendance (study_id, user_id, attendance_date, activated) VALUES (3, 2, '2025-07-03', TRUE);
 
 INSERT INTO group_chat_room (study_id, activated) VALUES (1, true);
-INSERT INTO group_chat_room (study_id, activated) VALUES (2, true);
+INSERT INTO group_chat_room (study_id, activated) VALUES (6, true);
 
 INSERT INTO group_chat_message (room_id, user_id, message, activated) VALUES (1, 1, '안녕하세요! 스터디 언제 시작하나요?', TRUE);
 INSERT INTO group_chat_message (room_id, user_id, message, activated) VALUES (1, 2, '오늘 저녁 8시에 시작해요!', TRUE);

--- a/src/main/resources/static/Chat-Test.html
+++ b/src/main/resources/static/Chat-Test.html
@@ -10,8 +10,8 @@
 <h2>그룹 채팅 테스트 (로컬 서버)</h2>
 
 <div>
-  <label>Room ID: </label>
-  <input type="number" id="roomId" value="1">
+  <label>Study ID: </label>
+  <input type="number" id="studyId" value="1">
   <label>Sender ID: </label>
   <input type="number" id="senderId" value="10">
   <button onclick="connect()">연결하기</button>
@@ -30,11 +30,11 @@
 
 <script>
   let stompClient = null;
-  let currentRoomId = null;
+  let currentStudyId = null;
 
   function connect() {
-    const roomId = document.getElementById("roomId").value || 1;
-    currentRoomId = roomId;
+    const studyId = document.getElementById("studyId").value || 1;
+    currentStudyId = studyId;
 
     // 로컬 서버용 WebSocket 엔드포인트
     const socket = new SockJS("http://localhost:8083/ws-stomp");
@@ -42,10 +42,10 @@
 
     stompClient.connect({}, function (frame) {
       console.log("WebSocket 연결 성공:", frame);
-      alert("채팅방 " + roomId + "에 연결되었습니다!");
+      alert("스터디 " + studyId + "에 연결되었습니다!");
 
       // 채팅방 구독
-      stompClient.subscribe(`/sub/chat/room/${roomId}`, function (message) {
+      stompClient.subscribe(`/sub/chat/study/${studyId}`, function (message) {
         const chat = JSON.parse(message.body);
         showMessage(chat.senderNickname + ": " + chat.message);
       });
@@ -58,7 +58,7 @@
 
     if (stompClient && stompClient.connected) {
       stompClient.send("/pub/chat/message", {}, JSON.stringify({
-        roomId: currentRoomId,
+        studyId: currentStudyId,
         senderId: senderId,
         message: messageContent
       }));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#54 
## 📌 과제 설명 

**기존 그룹 채팅 로직은 roomId 기반으로 동작했으나, 스터디(Study)와 채팅방의 흐름이 직관적으로 연결되지 않는 문제가 있었습니다.
특히 스터디 생성 → 채팅방 생성 → 채팅 연결 과정에서 roomId를 알 수 없는 이슈가 발생했고, 프론트엔드 테스트 시 혼동이 발생했습니다.**

## 👩‍💻 요구 사항과 구현 내용 
## 채팅방 식별자 변경 (roomId → studyId)
- 그룹 채팅의 주요 흐름을 studyId 중심으로 전면 리팩토링.
- GroupChatService, WebSocketController, RestController, DTO (Request/Response)에서 roomId를 studyId로 통일.
- Swagger 문서(GroupChatSwaggerController, GroupChatSwaggerSpecification) 및 예시 데이터도 studyId 기준으로 수정.

