### PR TITLE
[EA3-111] feature : 과거 채팅 응답구조 개선 및 dto 추가

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestController.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestController.java
@@ -1,5 +1,6 @@
 package grep.neogulcoder.domain.groupchat.controller;
 
+import grep.neogulcoder.domain.groupchat.controller.dto.response.ChatMessagePagingResponse;
 import grep.neogulcoder.domain.groupchat.controller.dto.response.GroupChatMessageResponseDto;
 import grep.neogulcoder.domain.groupchat.service.GroupChatService;
 import grep.neogulcoder.global.response.ApiResponse;
@@ -17,15 +18,13 @@ public class GroupChatRestController implements GroupChatRestSpecification {
     // 과거 채팅 메시지 페이징 조회 (무한 스크롤용)
     @Override
     @GetMapping("/study/{studyId}/messages")
-    public ApiResponse<PageResponse<GroupChatMessageResponseDto>> getMessages(
+    public ApiResponse<ChatMessagePagingResponse> getMessages(
         @PathVariable("studyId") Long studyId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size
     ) {
         // 서비스에서 페이징된 메시지 조회
-        PageResponse<GroupChatMessageResponseDto> pageResponse =
-            groupChatService.getMessages(studyId, page, size);
-
-        return ApiResponse.success(pageResponse);
+        ChatMessagePagingResponse response = groupChatService.getMessages(studyId, page, size);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestSpecification.java
@@ -1,5 +1,6 @@
 package grep.neogulcoder.domain.groupchat.controller;
 
+import grep.neogulcoder.domain.groupchat.controller.dto.response.ChatMessagePagingResponse;
 import grep.neogulcoder.domain.groupchat.controller.dto.response.GroupChatMessageResponseDto;
 import grep.neogulcoder.global.response.ApiResponse;
 import grep.neogulcoder.global.response.PageResponse;
@@ -73,7 +74,7 @@ public interface GroupChatRestSpecification {
         """
     )
 
-    ApiResponse<PageResponse<GroupChatMessageResponseDto>> getMessages(
+    ApiResponse<ChatMessagePagingResponse> getMessages(
         @Parameter(description = "스터디 ID", example = "1")
         @PathVariable("studyId") Long studyId,
 

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/response/ChatMessagePagingResponse.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/dto/response/ChatMessagePagingResponse.java
@@ -1,0 +1,44 @@
+package grep.neogulcoder.domain.groupchat.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class ChatMessagePagingResponse {
+
+    @Schema(description = "채팅 메시지 목록")
+    private final List<GroupChatMessageResponseDto> content;
+
+    @Schema(description = "현재 페이지 번호", example = "0")
+    private final int currentPage;
+
+    @Schema(description = "페이지 크기", example = "20")
+    private final int size;
+
+    @Schema(description = "전체 페이지 수", example = "5")
+    private final int totalPages;
+
+    @Schema(description = "전체 메시지 수", example = "100")
+    private final long totalElements;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private final boolean hasNext;
+
+    @Builder
+    private ChatMessagePagingResponse(Page<GroupChatMessageResponseDto> page) {
+        this.content = page.getContent();
+        this.currentPage = page.getNumber();
+        this.size = page.getSize();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.hasNext = page.hasNext();
+    }
+
+    public static ChatMessagePagingResponse of(Page<GroupChatMessageResponseDto> page) {
+        return new ChatMessagePagingResponse(page);
+    }
+}

--- a/src/main/java/grep/neogulcoder/domain/groupchat/repository/GroupChatMessageRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/repository/GroupChatMessageRepository.java
@@ -11,7 +11,8 @@ public interface GroupChatMessageRepository extends JpaRepository<GroupChatMessa
 
     // 채팅방(roomId)에 속한 메시지를 전송 시간 내림차순으로 페이징 조회
     @Query("SELECT m FROM GroupChatMessage m " +
-        "WHERE m.groupChatRoom.roomId = :roomId " +
+        "JOIN FETCH m.groupChatRoom r " +
+        "WHERE r.roomId = :roomId " +
         "ORDER BY m.sentAt ASC")
     Page<GroupChatMessage> findMessagesByRoomIdAsc(@Param("roomId") Long roomId, Pageable pageable);
 

--- a/src/main/java/grep/neogulcoder/domain/groupchat/service/GroupChatService.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/service/GroupChatService.java
@@ -1,5 +1,6 @@
 package grep.neogulcoder.domain.groupchat.service;
 
+import grep.neogulcoder.domain.groupchat.controller.dto.response.ChatMessagePagingResponse;
 import grep.neogulcoder.domain.groupchat.entity.GroupChatMessage;
 import grep.neogulcoder.domain.groupchat.entity.GroupChatRoom;
 import grep.neogulcoder.domain.groupchat.controller.dto.requset.GroupChatMessageRequestDto;
@@ -63,7 +64,8 @@ public class GroupChatService {
     }
 
     // 과거 채팅 메시지 페이징 조회 (무한 스크롤용)
-    public PageResponse<GroupChatMessageResponseDto> getMessages(Long studyId, int page, int size) {
+    @Transactional(readOnly = true)
+    public ChatMessagePagingResponse getMessages(Long studyId, int page, int size) {
         GroupChatRoom room = roomRepository.findByStudyId(studyId)
             .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
 
@@ -81,12 +83,7 @@ public class GroupChatService {
             return GroupChatMessageResponseDto.from(message, sender);
         });
 
-        // PageResponse로 감싸서 반환
-        return new PageResponse<>(
-            "/api/chat/study/" + studyId + "/messages",
-            messagePage,
-            5 // 페이지 버튼 개수
-        );
+        return ChatMessagePagingResponse.of(messagePage);
     }
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
#54 
## 📌 과제 설명
**그룹 채팅의 과거 메시지 페이징 조회 API 응답 구조를 단순화하고 직렬화 문제를 해결하기 위해 ChatMessagePagingResponse를 추가하고, 서비스/컨트롤러를 리팩토링했습니다.**

## 👩‍💻 요구 사항과 구현 내용 
**ChatMessagePagingResponse DTO 추가**
- content, currentPage, size, totalPages, totalElements, hasNext 필드 추가.
- 프론트엔드 무한 스크롤 구현을 위해 단순화된 구조로 응답하도록 설계.

**GroupChatService.getMessages() 리팩토링**
- 기존 PageResponse 반환을 제거하고 ChatMessagePagingResponse로 변경.
- Page<GroupChatMessage>를 Page<GroupChatMessageResponseDto>로 변환 후 DTO에 매핑.

**GroupChatRestController 수정**
- 반환 타입을 ApiResponse<ChatMessagePagingResponse>로 변경.
- GroupChatRestSpecification 인터페이스의 반환 타입도 일치시킴.

**GroupChatMessageRepository 쿼리**
- JOIN FETCH 추가로 LazyInitializationException 해결

## ✅ 피드백 반영사항 
<img width="700" height="503" alt="image" src="https://github.com/user-attachments/assets/0a5085f0-5961-4a0c-be85-0d5fdd89a1ec" />

<img width="560" height="497" alt="image" src="https://github.com/user-attachments/assets/001dd642-3be6-4c7a-97f1-5d6763869b7b" />
