### PR TITLE
[EA3-183] refactor : 모임 일정 조율 관련 전면 리팩토링(hard delete → soft delete + 스케줄러로 삭제)

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/timevote/TimeVoteStat.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/TimeVoteStat.java
@@ -34,18 +34,13 @@ public class TimeVoteStat extends BaseEntity {
   @Column(nullable = false)
   private Long voteCount;
 
-  @Version
-  @Column(nullable = false)
-  private Long version;
-
   protected TimeVoteStat() {}
 
   @Builder
-  public TimeVoteStat(TimeVotePeriod period, LocalDateTime timeSlot, Long voteCount, Long version) {
+  public TimeVoteStat(TimeVotePeriod period, LocalDateTime timeSlot, Long voteCount) {
     this.period = period;
     this.timeSlot = timeSlot;
     this.voteCount = voteCount;
-    this.version = version;
   }
 
   public static TimeVoteStat of(TimeVotePeriod period, LocalDateTime timeSlot, Long voteCount) {
@@ -53,12 +48,11 @@ public class TimeVoteStat extends BaseEntity {
         .period(period)
         .timeSlot(timeSlot)
         .voteCount(voteCount)
-        .version(0L)
         .build();
   }
 
   public void addVotes(Long countToAdd) {
-    log.debug("addVotes: 이전 voteCount={}, 추가 count={}, 이전 version={}", this.voteCount, countToAdd, this.version);
+    log.debug("addVotes: 이전 voteCount={}, 추가 count={}, 이전 version={}", this.voteCount, countToAdd);
     this.voteCount += countToAdd;
   }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/exception/code/TimeVoteErrorCode.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/exception/code/TimeVoteErrorCode.java
@@ -17,6 +17,7 @@ public enum TimeVoteErrorCode implements ErrorCode {
   INVALID_TIME_VOTE_PERIOD("TVP_003", HttpStatus.BAD_REQUEST, "모일 일정 조율 기간은 최대 7일까지 설정할 수 있습니다."),
   TIME_VOTE_PERIOD_START_DATE_IN_PAST("TVP_004", HttpStatus.BAD_REQUEST, "투표 시작일은 현재 시각보다 이전일 수 없습니다."),
   TIME_VOTE_INVALID_DATE_RANGE("TVP_005", HttpStatus.BAD_REQUEST, "종료일은 시작일보다 이후여야 합니다."),
+  TIME_VOTE_DELETE_FAILED("TVP_006", HttpStatus.INTERNAL_SERVER_ERROR, "기존 투표 데이터 삭제 중 오류가 발생했습니다."),
 
   // Time Vote, Time Vote Stats (e.g. 투표 기간 관련)
   TIME_VOTE_OUT_OF_RANGE("TVAS_001", HttpStatus.BAD_REQUEST, "선택한 시간이 투표 기간을 벗어났습니다."),

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVotePeriodRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVotePeriodRepository.java
@@ -3,12 +3,17 @@ package grep.neogulcoder.domain.timevote.repository;
 import grep.neogulcoder.domain.timevote.TimeVotePeriod;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TimeVotePeriodRepository extends JpaRepository<TimeVotePeriod, Long> {
 
-  void deleteAllByStudyId(Long studyId);
+  @Modifying
+  @Query("UPDATE TimeVotePeriod p SET p.activated = false WHERE p.studyId = :studyId")
+  void deactivateAllByStudyId(@Param("studyId") Long studyId);
 
-  boolean existsByStudyId(Long studyId);
+  boolean existsByStudyIdAndActivatedTrue(Long studyId);
 
-  Optional<TimeVotePeriod> findTopByStudyIdOrderByStartDateDesc(Long studyId);
+  Optional<TimeVotePeriod> findTopByStudyIdAndActivatedTrueOrderByStartDateDesc(Long studyId);
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteQueryRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteQueryRepository.java
@@ -1,9 +1,7 @@
 package grep.neogulcoder.domain.timevote.repository;
 
-import com.querydsl.core.types.dsl.BooleanPath;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import grep.neogulcoder.domain.study.QStudyMember;
 import grep.neogulcoder.domain.timevote.dto.response.TimeVoteSubmissionStatusResponse;
@@ -24,45 +22,44 @@ public class TimeVoteQueryRepository {
     this.queryFactory = new JPAQueryFactory(em);
   }
 
-  public List<TimeVoteSubmissionStatusResponse> findSubmissionStatuses(Long studyId, Long periodId) {
+  public List<TimeVoteSubmissionStatusResponse> findSubmissionStatuses(Long studyId,
+      Long periodId) {
     QStudyMember studyMember = QStudyMember.studyMember;
     QTimeVote timeVote = QTimeVote.timeVote;
     QUser user = QUser.user;
 
-    // select절에서 alias를 지정해 Tuple에서 이름 기반으로 값을 꺼낼 수 있도록 Path 객체 생성
-    NumberPath<Long> aliasStudyMemberId = Expressions.numberPath(Long.class, "aliasStudyMemberId");
-    StringPath aliasNickname = Expressions.stringPath("aliasNickname");
-    StringPath aliasProfileImageUrl = Expressions.stringPath("aliasProfileImageUrl");
-    BooleanPath aliasIsSubmitted = Expressions.booleanPath("aliasIsSubmitted");
+    BooleanExpression existsVoteSubquery = JPAExpressions
+        .selectOne()
+        .from(timeVote)
+        .where(
+            timeVote.studyMemberId.eq(studyMember.id)
+                .and(timeVote.period.periodId.eq(periodId))
+                .and(timeVote.activated.isTrue())
+        )
+        .exists();
+
 
     List<Tuple> results = queryFactory
         .select(
-            studyMember.id.as(aliasStudyMemberId),
-            user.nickname.as(aliasNickname),
-            user.profileImageUrl.as(aliasProfileImageUrl),
-            timeVote.voteId.count().gt(0).as(aliasIsSubmitted)
+            studyMember.id,
+            user.nickname,
+            user.profileImageUrl,
+            existsVoteSubquery
         )
         .from(studyMember)
-        .leftJoin(user).on(studyMember.userId.eq(user.id))
-        .leftJoin(timeVote).on(
-            timeVote.period.periodId.eq(periodId)
-                .and(timeVote.studyMemberId.eq(studyMember.id))
-        )
+        .join(user).on(studyMember.userId.eq(user.id))
         .where(
             studyMember.study.id.eq(studyId),
             studyMember.activated.isTrue()
         )
-        // 중복 방지 (id, 닉네임, 프로필 기준으로 그룹핑)
-        .groupBy(studyMember.id, user.nickname, user.profileImageUrl)
         .fetch();
 
-    // Tuple 결과를 DTO 로 변환 (alias 기반으로 값 추출)
     return results.stream()
         .map(tuple -> TimeVoteSubmissionStatusResponse.builder()
-            .studyMemberId(tuple.get(aliasStudyMemberId))
-            .nickname(tuple.get(aliasNickname))
-            .profileImageUrl(tuple.get(aliasProfileImageUrl))
-            .isSubmitted(tuple.get(aliasIsSubmitted))
+            .studyMemberId(tuple.get(studyMember.id))
+            .nickname(tuple.get(user.nickname))
+            .profileImageUrl(tuple.get(user.profileImageUrl))
+            .isSubmitted(tuple.get(existsVoteSubquery))
             .build())
         .collect(Collectors.toList());
   }

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteRepository.java
@@ -4,14 +4,21 @@ import grep.neogulcoder.domain.timevote.TimeVote;
 import grep.neogulcoder.domain.timevote.TimeVotePeriod;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TimeVoteRepository extends JpaRepository<TimeVote, Long> {
 
-  void deleteAllByPeriod_StudyId(Long studyId);
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE TimeVote v SET v.activated = false WHERE v.period.studyId = :studyId")
+  void deactivateAllByPeriod_StudyId(@Param("studyId") Long studyId);
 
-  List<TimeVote> findByPeriodAndStudyMemberId(TimeVotePeriod period, Long userId);
+  List<TimeVote> findByPeriodAndStudyMemberIdAndActivatedTrue(TimeVotePeriod period, Long studyMemberId);
 
-  void deleteAllByPeriodAndStudyMemberId(TimeVotePeriod period, Long studyMemberId);
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE TimeVote v SET v.activated = false WHERE v.period = :period AND v.studyMemberId = :memberId")
+  void deactivateByPeriodAndStudyMember(@Param("period") TimeVotePeriod period, @Param("memberId") Long memberId);
 
-  boolean existsByPeriodAndStudyMemberId(TimeVotePeriod period, Long studyMemberId);
+  boolean existsByPeriodAndStudyMemberIdAndActivatedTrue(TimeVotePeriod period, Long studyMemberId);
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteStatQueryRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteStatQueryRepository.java
@@ -8,8 +8,10 @@ import grep.neogulcoder.domain.timevote.QTimeVote;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 public class TimeVoteStatQueryRepository {
 
@@ -33,6 +35,10 @@ public class TimeVoteStatQueryRepository {
         )
         .groupBy(timeVote.timeSlot)
         .fetch();
+
+    for (Tuple tuple : result) {
+      log.info(">>> 통계 디버깅: timeSlot={}, count={}", tuple.get(timeVote.timeSlot), tuple.get(timeVote.count()));
+    }
 
     return result.stream()
         .map(tuple -> TimeVoteStat.of(period, tuple.get(timeVote.timeSlot), tuple.get(timeVote.count())))

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteStatRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteStatRepository.java
@@ -2,17 +2,57 @@ package grep.neogulcoder.domain.timevote.repository;
 
 import grep.neogulcoder.domain.timevote.TimeVotePeriod;
 import grep.neogulcoder.domain.timevote.TimeVoteStat;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TimeVoteStatRepository extends JpaRepository<TimeVoteStat, Long> {
 
-  void deleteAllByPeriod_StudyId(Long studyId);
+  @Modifying
+  @Query("UPDATE TimeVoteStat s SET s.activated = false WHERE s.period.studyId = :studyId")
+  void deactivateAllByPeriod_StudyId(@Param("studyId") Long studyId);
 
-  void deleteByPeriod(TimeVotePeriod period);
 
-  @Query("SELECT s FROM TimeVoteStat s WHERE s.period.periodId = :periodId")
+  @Modifying
+  @Query("UPDATE TimeVoteStat s SET s.activated = false WHERE s.period = :period")
+  void softDeleteByPeriod(@Param("period") TimeVotePeriod period);
+
+  @Query("SELECT s FROM TimeVoteStat s WHERE s.period.periodId = :periodId AND s.activated = true")
   List<TimeVoteStat> findAllByPeriodId(@Param("periodId") Long periodId);
+
+  @Modifying(clearAutomatically = true)
+  @Query(value = """
+
+      INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, created_date, modified_date)
+    VALUES (:periodId, :timeSlot, :count, true, now(), now())
+    ON CONFLICT (period_id, time_slot)
+    DO UPDATE SET
+      vote_count = time_vote_stat.vote_count + EXCLUDED.vote_count,
+      modified_date = now(),
+      activated = true
+    """, nativeQuery = true)
+  void upsertVoteStat(
+      @Param("periodId") Long periodId,
+      @Param("timeSlot") LocalDateTime timeSlot,
+      @Param("count") Long count
+  );
+
+  @Modifying(clearAutomatically = true)
+  @Query(value = """
+    INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, created_date, modified_date)
+    VALUES (:periodId, :timeSlot, :voteCount, true, now(), now())
+    ON CONFLICT (period_id, time_slot)
+    DO UPDATE SET
+      vote_count = EXCLUDED.vote_count,
+      modified_date = now(),
+      activated = true
+    """, nativeQuery = true)
+  void bulkUpsertStat(
+      @Param("periodId") Long periodId,
+      @Param("timeSlot") LocalDateTime timeSlot,
+      @Param("voteCount") Long voteCount
+  );
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/TimeVoteMapper.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/TimeVoteMapper.java
@@ -42,4 +42,14 @@ public class TimeVoteMapper {
             .build())
         .collect(Collectors.toList());
   }
+
+  public List<TimeVote> toEntities(List<LocalDateTime> timeSlots, TimeVotePeriod period, Long studyMemberId) {
+    return timeSlots.stream()
+        .map(slot -> TimeVote.builder()
+            .period(period)
+            .studyMemberId(studyMemberId)
+            .timeSlot(slot)
+            .build())
+        .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/period/TimeVotePeriodService.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/period/TimeVotePeriodService.java
@@ -11,10 +11,12 @@ import grep.neogulcoder.domain.timevote.service.TimeVoteMapper;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -28,30 +30,46 @@ public class TimeVotePeriodService {
   private final ApplicationEventPublisher eventPublisher;
 
   public TimeVotePeriodResponse createTimeVotePeriodAndReturn(TimeVotePeriodCreateRequest request, Long studyId, Long userId) {
+    log.info("[TimeVotePeriod] 투표 기간 생성 시작 - studyId={}, userId={}, 요청={}", studyId, userId, request);
+
     // 입력값 검증 (스터디 존재, 멤버 활성화 여부, 리더 여부, 날짜 유효성 등)
     timeVotePeriodValidator.validatePeriodCreateRequestAndReturnMember(request, studyId, userId);
-
     LocalDateTime adjustedEndDate = adjustEndDate(request.getEndDate());
 
-    if (timeVotePeriodRepository.existsByStudyId(studyId)) { deleteAllTimeVoteDate(studyId); }
+    if (timeVotePeriodRepository.existsByStudyIdAndActivatedTrue(studyId)) {
+      log.info("[TimeVotePeriod] 기존 투표 기간 존재, 전체 투표 데이터 삭제 진행");
+      deleteAllTimeVoteDate(studyId);
+    }
 
     TimeVotePeriod savedPeriod = timeVotePeriodRepository.save(timeVoteMapper.toEntity(request, studyId, adjustedEndDate));
+    log.info("[TimeVotePeriod] 투표 기간 저장 완료 - periodId={}", savedPeriod.getPeriodId());
 
     // 알림 메시지를 위한 스터디 유효성 검증 (존재 확인)
     timeVotePeriodValidator.getValidStudy(studyId);
 
     // 리더 자신을 제외한 나머지 멤버들에게 투표 요청 알림 저장
     eventPublisher.publishEvent(new TimeVotePeriodCreatedEvent(studyId, userId));
+    log.info("[TimeVotePeriod] 투표 요청 알림 이벤트 발행 완료 - studyId={}, userId={}", studyId, userId);
     return TimeVotePeriodResponse.from(savedPeriod);
   }
 
   // 해당 스터디 ID로 등록된 모든 투표 관련 데이터 삭제
   public void deleteAllTimeVoteDate(Long studyId) {
+    long start = System.currentTimeMillis();
+    log.info("[TimeVotePeriod] 전체 투표 데이터 삭제 시작 - studyId={}", studyId);
+
     timeVotePeriodValidator.getValidStudy(studyId);
 
-    timeVoteRepository.deleteAllByPeriod_StudyId(studyId);
-    timeVoteStatRepository.deleteAllByPeriod_StudyId(studyId);
-    timeVotePeriodRepository.deleteAllByStudyId(studyId);
+    timeVoteRepository.deactivateAllByPeriod_StudyId(studyId);
+    log.info("[TimeVotePeriod] 투표 soft delete 완료");
+
+    timeVoteStatRepository.deactivateAllByPeriod_StudyId(studyId);
+    log.info("[TimeVotePeriod] 통계 soft delete 완료");
+
+    timeVotePeriodRepository.deactivateAllByStudyId(studyId);
+    log.info("[TimeVotePeriod] 투표 기간 hard delete 완료");
+
+    log.info("[TimeVotePeriod] 전체 삭제 완료 - {}ms 소요", System.currentTimeMillis() - start);
   }
 
   // 투표 기간의 종료일을 '해당 일의 23:59:59'로 보정

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/stat/TimeVoteStatService.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/stat/TimeVoteStatService.java
@@ -9,15 +9,15 @@ import grep.neogulcoder.domain.timevote.TimeVoteStat;
 import grep.neogulcoder.domain.timevote.repository.TimeVoteStatQueryRepository;
 import grep.neogulcoder.domain.timevote.repository.TimeVoteStatRepository;
 import grep.neogulcoder.global.exception.business.BusinessException;
-import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PersistenceException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,9 +33,12 @@ public class TimeVoteStatService {
 
   @Transactional(readOnly = true)
   public TimeVoteStatResponse getStats(Long studyId, Long userId) {
+    log.info("[통계 조회] 시작 - studyId={}, userId={}", studyId, userId);
+
     TimeVoteContext context = timeVoteStatValidator.getValidatedContext(studyId, userId);
 
     List<TimeVoteStat> stats = timeVoteStatRepository.findAllByPeriodId(context.period().getPeriodId());
+    log.info("[통계 조회] 조회된 통계 개수 = {}", stats.size());
 
     timeVoteStatValidator.validateStatTimeSlotsWithinPeriod(context.period(), stats);
 
@@ -49,57 +52,33 @@ public class TimeVoteStatService {
     Map<LocalDateTime, Long> countMap = timeSlots.stream()
         .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
-    List<LocalDateTime> failedSlots = new ArrayList<>();
-
-    countMap.forEach((slot, count) -> {
-      boolean success = false;
-      int retry = 0;
-
-      while (!success && retry < 3) {
-        try {
-          timeVoteStatQueryRepository.incrementOrInsert(period, slot, count);
-          success = true;
-        } catch (OptimisticLockException e) {
-          retry++;
-          // 현재 version 로그는 트랜잭션 커밋 시점에 확인 필요
-          log.warn("[TimeVoteStatService] 낙관적 락 충돌 발생: periodId={}, slot={}, count={}, 재시도 {}/3, 원인={}",
-              period.getPeriodId(), slot, count, retry, e.getMessage()); // 통계 동시성 충돌 시 재시도 (최대 3회)
-          try {
-            Thread.sleep(10L);
-          } catch (InterruptedException e2) {
-            Thread.currentThread().interrupt();
-            throw new BusinessException(TIME_VOTE_THREAD_INTERRUPTED);
-          }
-        }
+    try {
+      for (Map.Entry<LocalDateTime, Long> entry : countMap.entrySet()) {
+        timeVoteStatRepository.upsertVoteStat( period.getPeriodId(), entry.getKey(), entry.getValue());
       }
-
-      if (!success) {
-        failedSlots.add(slot); // 실패한 slot 따로 저장
-      }
-    });
-
-    if (!failedSlots.isEmpty()) {
-      log.error("[TimeVoteStatService] 통계 반영 실패: periodId={}, 실패 slot 목록={}", periodId, failedSlots);
-      throw new BusinessException(TIME_VOTE_STAT_CONFLICT);
+      log.info("[TimeVoteStatService] 투표 통계 반영 완료: periodId={}, 총 {}개의 슬롯", periodId, countMap.size());
+    } catch (Exception e) {
+      log.error("[TimeVoteStatService] 통계 반영 실패: periodId={}, 원인={}", periodId, e.getMessage(), e);
+      throw new BusinessException(TIME_VOTE_STAT_FATAL);
     }
   }
 
   public void recalculateStats(Long periodId) {
     log.info("[TimeVoteStatService] 투표 통계 재계산 시작: periodId={}", periodId);
+    TimeVotePeriod period = timeVoteStatValidator.getValidTimeVotePeriodByPeriodId(periodId);
+
+    timeVoteStatRepository.softDeleteByPeriod(period);
+
+    List<TimeVoteStat> stats = timeVoteStatQueryRepository.countStatsByPeriod(period);
+
     try {
-      synchronized (("recalc-lock:" + periodId).intern()) {
-        TimeVotePeriod period = timeVoteStatValidator.getValidTimeVotePeriodByPeriodId(periodId);
-
-        timeVoteStatRepository.deleteByPeriod(period);
-
-        List<TimeVoteStat> stats = timeVoteStatQueryRepository.countStatsByPeriod(period);
-
-        timeVoteStatRepository.saveAll(stats);
-
-        log.info("[TimeVoteStatService] 통계 재계산 완료: 저장된 slot 수 = {}", stats.size());
+      for (TimeVoteStat stat : stats) {
+        timeVoteStatRepository.bulkUpsertStat(stat.getPeriod().getPeriodId(), stat.getTimeSlot(), stat.getVoteCount());
       }
-    } catch (Exception e) {
-      log.error("[TimeVoteStatService] 통계 재계산 실패: periodId={}, 원인={}", periodId, e.getMessage(), e);
+      log.info("[TimeVoteStatService] 투표 통계 재계산 완료: periodId={}, 총 {}개의 슬롯", periodId, stats.size());
+    } catch (DataAccessException | PersistenceException e) {
+      log.error("[TimeVoteStatService] 통계 upsert 실패: periodId={}, 원인={}", periodId, e.getMessage(),
+          e);
       throw new BusinessException(TIME_VOTE_STAT_FATAL);
     }
   }

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/stat/TimeVoteStatService.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/stat/TimeVoteStatService.java
@@ -45,24 +45,6 @@ public class TimeVoteStatService {
     return TimeVoteStatResponse.from(context.period(), stats);
   }
 
-  public void incrementStats(Long periodId, List<LocalDateTime> timeSlots) {
-    log.info("[TimeVoteStatService] 투표 통계 계산 시작: periodId={}, timeSlots={}", periodId, timeSlots);
-    TimeVotePeriod period = timeVoteStatValidator.getValidTimeVotePeriodByPeriodId(periodId);
-
-    Map<LocalDateTime, Long> countMap = timeSlots.stream()
-        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-
-    try {
-      for (Map.Entry<LocalDateTime, Long> entry : countMap.entrySet()) {
-        timeVoteStatRepository.upsertVoteStat( period.getPeriodId(), entry.getKey(), entry.getValue());
-      }
-      log.info("[TimeVoteStatService] 투표 통계 반영 완료: periodId={}, 총 {}개의 슬롯", periodId, countMap.size());
-    } catch (Exception e) {
-      log.error("[TimeVoteStatService] 통계 반영 실패: periodId={}, 원인={}", periodId, e.getMessage(), e);
-      throw new BusinessException(TIME_VOTE_STAT_FATAL);
-    }
-  }
-
   public void recalculateStats(Long periodId) {
     log.info("[TimeVoteStatService] 투표 통계 재계산 시작: periodId={}", periodId);
     TimeVotePeriod period = timeVoteStatValidator.getValidTimeVotePeriodByPeriodId(periodId);

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/stat/TimeVoteStatValidator.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/stat/TimeVoteStatValidator.java
@@ -53,7 +53,7 @@ public class TimeVoteStatValidator {
   }
 
   private TimeVotePeriod getValidTimeVotePeriodByStudyId(Long studyId) {
-    return timeVotePeriodRepository.findTopByStudyIdOrderByStartDateDesc(studyId)
+    return timeVotePeriodRepository.findTopByStudyIdAndActivatedTrueOrderByStartDateDesc(studyId)
         .orElseThrow(() -> new BusinessException(TIME_VOTE_PERIOD_NOT_FOUND));
   }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteCleanupScheduler.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteCleanupScheduler.java
@@ -1,0 +1,43 @@
+package grep.neogulcoder.domain.timevote.service.vote;
+
+import grep.neogulcoder.domain.timevote.service.stat.TimeVoteStatService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class TimeVoteCleanupScheduler {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final TimeVoteStatService timeVoteStatService;
+
+  // 매일 새벽 3시: soft delete 된 투표 실제 삭제
+  @Scheduled(cron = "0 0 3 * * ?")
+  public void hardDeleteDeactivatedVotes() {
+    log.info("[Scheduler] Soft 삭제된 데이터 통계 재계산 시작");
+
+    // 통계 재계산 로직 호출 (soft delete된 period 기준으로)
+    List<Long> periodIds = jdbcTemplate.queryForList(
+        "SELECT DISTINCT period_id FROM time_vote WHERE activated = false", Long.class
+    );
+    periodIds.forEach(timeVoteStatService::recalculateStats);
+
+    log.info("[Scheduler] 통계 재계산 완료 - {}건", periodIds.size());
+
+    int deletedVotes = jdbcTemplate.update("DELETE FROM time_vote WHERE activated = false");
+    log.info("[Scheduler] Soft 삭제된 투표 {}건 실제 삭제 완료", deletedVotes);
+
+    int deletedStats = jdbcTemplate.update("DELETE FROM time_vote_stat WHERE activated = false");
+    log.info("[Scheduler] Soft 삭제된 통계 {}건 실제 삭제 완료", deletedStats);
+
+    int deletedPeriods = jdbcTemplate.update("DELETE FROM time_vote_period WHERE activated = false");
+    log.info("[Scheduler] Soft 삭제된 투표 기간 {}건 실제 삭제 완료", deletedPeriods);
+  }
+}

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteService.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteService.java
@@ -12,10 +12,12 @@ import grep.neogulcoder.domain.timevote.service.TimeVoteMapper;
 import grep.neogulcoder.domain.timevote.service.stat.TimeVoteStatService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @Transactional
 @RequiredArgsConstructor
 public class TimeVoteService {
@@ -28,44 +30,66 @@ public class TimeVoteService {
 
   @Transactional(readOnly = true)
   public TimeVoteResponse getMyVotes(Long studyId, Long userId) {
+    log.info("[TimeVote] 사용자 투표 조회 시작 - studyId={}, userId={}", studyId, userId);
     // 투표 전 필요한 모든 유효성 검증 및 도메인 정보 캡슐화
     TimeVoteContext context = timeVoteValidator.getContext(studyId, userId);
-    List<TimeVote> votes = timeVoteRepository.findByPeriodAndStudyMemberId(context.period(),
+
+    List<TimeVote> votes = timeVoteRepository.findByPeriodAndStudyMemberIdAndActivatedTrue(context.period(),
         context.studyMember().getId());
 
+    log.info("[TimeVote] 사용자 ID={}의 투표 {}건 조회 완료", context.studyMember().getId(), votes.size());
     return TimeVoteResponse.from(context.studyMember().getId(), votes);
   }
 
   public TimeVoteResponse submitVotes(TimeVoteCreateRequest request, Long studyId, Long userId) {
+    long totalStart = System.currentTimeMillis();
+    log.info("[TimeVote] 투표 제출 시작 - studyId={}, userId={}, 요청 슬롯 수={}",
+        studyId, userId, request.getTimeSlots().size());
+
     // 투표 전 필요한 모든 유효성 검증 및 도메인 정보 캡슐화
     TimeVoteContext context = timeVoteValidator.getSubmitContext(studyId, userId, request.getTimeSlots());
 
+    long voteStart = System.currentTimeMillis();
     List<TimeVote> votes = timeVoteMapper.toEntities(request, context.period(), context.studyMember().getId());
     timeVoteRepository.saveAll(votes);
+    log.info("[TimeVote] 투표 저장 완료 - {}건, {}ms 소요", votes.size(), System.currentTimeMillis() - voteStart);
 
-    // 통계 반영
+    long statStart = System.currentTimeMillis();
     timeVoteStatService.incrementStats(context.period().getPeriodId(), request.getTimeSlots());
+    log.info("[TimeVote] 통계 반영 완료 - {}ms 소요", System.currentTimeMillis() - statStart);
 
-    List<TimeVote> saved = timeVoteRepository.findByPeriodAndStudyMemberId(context.period(),
-        context.studyMember().getId());
+    List<TimeVote> saved = timeVoteRepository.findByPeriodAndStudyMemberIdAndActivatedTrue(context.period(), context.studyMember().getId());
+    log.info("[TimeVote] 저장된 투표 재조회 완료 - {}건", saved.size());
+
+    log.info("[TimeVote] 투표 제출 전체 완료 - 총 {}ms 소요", System.currentTimeMillis() - totalStart);
 
     return TimeVoteResponse.from(context.studyMember().getId(), saved);
   }
 
   public TimeVoteResponse updateVotes(TimeVoteUpdateRequest request, Long studyId, Long userId) {
+    long totalStart = System.currentTimeMillis();
+    log.info("[TimeVote] 투표 수정 시작 - studyId={}, userId={}, 요청 슬롯 수={}", studyId, userId, request.getTimeSlots().size());
+
     // 투표 전 필요한 모든 유효성 검증 및 도메인 정보 캡슐화
     TimeVoteContext context = timeVoteValidator.getUpdateContext(studyId, userId, request.getTimeSlots());
 
-    timeVoteRepository.deleteAllByPeriodAndStudyMemberId(context.period(), context.studyMember().getId());
+    long deleteStart = System.currentTimeMillis();
+    timeVoteRepository.deactivateByPeriodAndStudyMember(context.period(), context.studyMember().getId());
+    log.info("[TimeVote] 기존 투표 soft delete 완료 - {}ms 소요", System.currentTimeMillis() - deleteStart);
 
+    long saveStart = System.currentTimeMillis();
     List<TimeVote> newVotes = timeVoteMapper.toEntities(request, context.period(), context.studyMember().getId());
     timeVoteRepository.saveAll(newVotes);
+    log.info("[TimeVote] 새로운 투표 저장 완료 - {}건, {}ms 소요", newVotes.size(), System.currentTimeMillis() - saveStart);
 
-    // 통계 재반영
+    long statStart = System.currentTimeMillis();
     timeVoteStatService.recalculateStats(context.period().getPeriodId());
+    log.info("[TimeVote] 통계 재계산 완료 - {}ms 소요", System.currentTimeMillis() - statStart);
 
-    List<TimeVote> saved = timeVoteRepository.findByPeriodAndStudyMemberId(context.period(),
-        context.studyMember().getId());
+    List<TimeVote> saved = timeVoteRepository.findByPeriodAndStudyMemberIdAndActivatedTrue(context.period(), context.studyMember().getId());
+    log.info("[TimeVote] 저장된 투표 재조회 완료 - {}건", saved.size());
+
+    log.info("[TimeVote] 투표 수정 전체 완료 - 총 {}ms 소요", System.currentTimeMillis() - totalStart);
 
     return TimeVoteResponse.from(context.studyMember().getId(), saved);
   }
@@ -74,15 +98,28 @@ public class TimeVoteService {
     // 투표 삭제 전 필요한 모든 유효성 검증 및 도메인 정보 캡슐화
     TimeVoteContext context = timeVoteValidator.getContext(studyId, userId);
 
-    timeVoteRepository.deleteAllByPeriodAndStudyMemberId(context.period(), context.studyMember().getId());
+    long start = System.currentTimeMillis();
+    log.info("[TimeVote] 전체 투표 삭제 시작 - studyId={}, userId={}", studyId, userId);
+
+    timeVoteRepository.deactivateByPeriodAndStudyMember(context.period(), context.studyMember().getId());
+    log.info("[TimeVote] 삭제 완료 - {}ms 소요", System.currentTimeMillis() - start);
+
+    start = System.currentTimeMillis();
+    log.info("[TimeVote] 통계 재계산 시작 - periodId={}", context.period().getPeriodId());
 
     timeVoteStatService.recalculateStats(context.period().getPeriodId());
+    log.info("[TimeVote] 통계 재계산 완료 - {}ms 소요", System.currentTimeMillis() - start);
   }
 
   public List<TimeVoteSubmissionStatusResponse> getSubmissionStatusList(Long studyId, Long userId) {
+    log.info("[TimeVote] 제출 현황 조회 시작 - studyId={}, userId={}", studyId, userId);
     // 사용자 제출 확인 전 필요한 모든 유효성 검증 및 도메인 정보 캡슐화
     TimeVoteContext context = timeVoteValidator.getContext(studyId, userId);
 
-    return timeVoteQueryRepository.findSubmissionStatuses(studyId, context.period().getPeriodId());
+    List<TimeVoteSubmissionStatusResponse> result =
+        timeVoteQueryRepository.findSubmissionStatuses(studyId, context.period().getPeriodId());
+
+    log.info("[TimeVote] 제출 현황 조회 완료 - 총 {}명", result.size());
+    return result;
   }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteValidator.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteValidator.java
@@ -84,7 +84,7 @@ public class TimeVoteValidator {
   }
 
   private TimeVotePeriod getValidTimeVotePeriod(Long studyId) {
-    return timeVotePeriodRepository.findTopByStudyIdOrderByStartDateDesc(studyId)
+    return timeVotePeriodRepository.findTopByStudyIdAndActivatedTrueOrderByStartDateDesc(studyId)
         .orElseThrow(() -> new BusinessException(TIME_VOTE_PERIOD_NOT_FOUND));
   }
 
@@ -117,7 +117,7 @@ public class TimeVoteValidator {
   }
 
   private void validateNotAlreadySubmitted(TimeVotePeriod period, Long studyMemberId) {
-    boolean alreadySubmitted = timeVoteRepository.existsByPeriodAndStudyMemberId(period,
+    boolean alreadySubmitted = timeVoteRepository.existsByPeriodAndStudyMemberIdAndActivatedTrue(period,
         studyMemberId);
     if (alreadySubmitted) {
       throw new BusinessException(TIME_VOTE_ALREADY_SUBMITTED);
@@ -125,7 +125,7 @@ public class TimeVoteValidator {
   }
 
   private void validateAlreadySubmitted(TimeVotePeriod period, Long studyMemberId) {
-    boolean alreadySubmitted = timeVoteRepository.existsByPeriodAndStudyMemberId(period,
+    boolean alreadySubmitted = timeVoteRepository.existsByPeriodAndStudyMemberIdAndActivatedTrue(period,
         studyMemberId);
     if (!alreadySubmitted) {
       throw new BusinessException(TIME_VOTE_NOT_FOUND);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -110,16 +110,16 @@ INSERT INTO time_vote (period_id, study_member_id, time_slot, activated) VALUES 
 INSERT INTO time_vote (period_id, study_member_id, time_slot, activated) VALUES (1, 8, '2025-07-29 20:00:00', TRUE);
 
 -- [ time_vote_stat ]
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-25 10:00:00', 2, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-25 11:00:00', 2, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-26 14:00:00', 3, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-26 15:00:00', 3, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-27 09:00:00', 1, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-27 13:00:00', 1, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-28 13:00:00', 3, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-28 14:00:00', 3, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-29 19:00:00', 2, TRUE, 0);
-INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated, version) VALUES (1, '2025-07-29 20:00:00', 1, TRUE, 0);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-25 10:00:00', 2, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-25 11:00:00', 2, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-26 14:00:00', 3, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-26 15:00:00', 3, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-27 09:00:00', 1, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-27 13:00:00', 1, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-28 13:00:00', 3, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-28 14:00:00', 3, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-29 19:00:00', 2, TRUE);
+INSERT INTO time_vote_stat (period_id, time_slot, vote_count, activated) VALUES (1, '2025-07-29 20:00:00', 1, TRUE);
 
 -- [ alarm ]
 -- 1. 스터디 초대 알림

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+-- 시간 투표 통계 테이블에서 기간(period_id) + 시간 슬롯(time_slot) 조합의 중복을 방지하고
+-- upsert 시 ON CONFLICT 조건을 성능 저하 없이 처리하기 위한 복합 유니크 인덱스
+CREATE UNIQUE INDEX uq_time_vote_stat_period_slot ON time_vote_stat (period_id, time_slot);
+
+-- 시간 투표 테이블에서 기간 및 사용자 기준으로 빠른 조인을 위해 인덱스 추가
+-- 사용자 기준 삭제 성능 향상을 위해 추가
+-- getSubmissionStatusList() 쿼리의 성능 최적화 목적
+CREATE INDEX idx_time_vote_period_member ON time_vote (period_id, study_member_id);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
References #228 

## 📌 과제 설명
- 기존에는 DB 크기 증가 방지를 위해 투표 및 통계 데이터를 사용자 액션 시점에 바로 **hard delete** 했습니다.
- 그러나 사용자가 동시에 여러 timeSlot을 제출하거나 수정하는 경우, **낙관적 락 기반 통계 반영** 방식에서 **과도한 동시 요청으로 인한 성능 저하*가 발생했습니다.
- 이를 해결하기 위해 통계는 **soft delete + 재계산 구조**, 삭제는 **스케줄러 기반 지연 hard delete 구조**로 전환했습니다.
- 이 구조는 **실시간 작업을 경량화**하고, **통계 일관성을 보장**하며, **삭제 시점 분리**를 통해 DB 안정성을 확보합니다.

## 👩‍💻 요구 사항과 구현 내용
### 1. 기존 통계 처리 로직 변경: 낙관적 락 → soft delete + bulk upsert
- **변경 전**: `incrementStats()`에서 개별 slot별 insert 또는 update 수행, 충돌 시 낙관적 락 + retry
- **변경 후**:
  - 사용자 액션(수정/삭제 등) 시 관련 통계 row를 `activated = false`로 soft delete
  - 이후 `bulkUpsertStat()`을 통해 새로운 통계를 일괄 반영
  - 스케줄러가 매일 새벽 3시에 soft delete 된 row를 일괄 hard delete 처리
- **이유**:
  - 낙관적 락은 동시성 높은 환경에서 retry 지연 발생 → 사용자 응답성 저하
  - soft delete + 스케줄링 삭제는 처리량과 정합성 모두에 유리
  - 삭제 후 통계 재계산 시점이 명확하므로 race condition 회피 가능

### 2. soft delete 기반 리팩토링
- **적용 대상**: `TimeVoteService`, `TimeVoteStatService`, `TimeVotePeriodService`
- **기능 적용**:
  - `BaseEntity`의 `unActivated()` 사용해 soft delete 처리
  - 기존의 `delete` 메서드를 `deactivate` 메서드로 전환
- **도입 이유**:
  - 사용자 액션마다 즉시 삭제하면 통계 누락 발생 위험
  - 삭제 시점과 통계 반영 시점을 분리함으로써 안정성 확보
  - soft delete 후 통계를 다시 계산할 수 있는 여지를 확보함

### 3. 매일 새벽 3시 스케줄러 통한 삭제 (`TimeVoteCleanupScheduler`)
- **기능**:
  - 3시 실행: soft delete된 `TimeVote` 기준 `period_id` 추출 → 통계 재계산
  - 재계산 완료 후 `TimeVote`, `TimeVoteStat` 테이블의 `activated = false` row 실제 삭제
- **이유**:
  - 사용자의 늦은 제출/수정 이후 통계 누락 방지
  - soft delete 데이터가 DB에 과도하게 쌓이는 것 방지
  - 실시간 삭제로 인한 부하 감소

### 4. 인덱스 추가
- **추가 인덱스**: `(period_id, activated)`
- **대상 테이블**: `time_vote`, `time_vote_stat`
- **도입 이유**:
  - soft delete로 인해 `activated = true` 조건이 쿼리마다 붙게 되어, 해당 조건에 대한 인덱스 없이는 성능 저하 유발
  - 통계 집계 시 주로 `period_id` 기준으로 조회됨 → 복합 인덱스 최적

### 5. 제출 여부, 통계 조회 쿼리 최적화
- **제출 여부 조회 (`TimeVoteQueryRepository`)**:
  - exists 서브쿼리 내부에 `activated = true` 조건 추가
  - fetch join 제거, BooleanExpression 분리로 성능 향상
- **통계 조회 (`TimeVoteStatQueryRepository`)**:
  - `activated = true` 조건 포함하여 soft delete 반영
  - 기존의 `incrementOrInsert()` 로직 제거하고 명확한 count 기반 통계 사용
  
## ♻️ 추가 리팩토링 및 코드 개선 사항
- TimeVoteService: submitVotes()와 updateVotes()의 중복 로직을 분리하여 executeVoteSubmission() 메서드로 통합
→ 투표 저장 및 통계 반영 로직을 재사용 가능하게 개선

- TimeVoteMapper: List<LocalDateTime>을 입력받는 공통 메서드 toEntities() 추가

- TimeVoteStatService: 더 이상 사용되지 않는 incrementStats() 제거
→ 통계 집계는 모두 recalculateStats() 방식으로 통일

- EntityManager 사용해 soft delete 이후 flush() 호출
→ deactivateByPeriodAndStudyMember() 실행 직후 flush()를 호출해 DB에 실제 반영
→ 그렇지 않으면 이후의 통계 재계산 쿼리(countStatsByPeriod)가 삭제 전 데이터를 기준으로 잘못된 통계 계산을 수행함
→ 따라서 flush()는 이 시점에 정합성 보장을 위해 필수적으로 수행됨

## ✅ PR 포인트 & 궁금한 점
- `application-local.properties`, `application-prod.properties`에 다음 설정을 추가해
기존 SQL 스크립트(schema.sql, data.sql)가 애플리케이션 구동 시 자동 반영되도록 설정 했습니다.
  ```properties
  spring.sql.init.schema-locations=classpath:schema.sql
  spring.sql.init.data-locations=classpath:data.sql

<img width="2032" height="1167" alt="스크린샷 2025-07-29 02 58 51" src="https://github.com/user-attachments/assets/ec7ef82d-e378-4b38-b46f-30f52fd98f14" />
<img width="1920" height="1080" alt="스크린샷 2025-07-29 03 00 09" src="https://github.com/user-attachments/assets/7e4d0f92-0fb1-4975-ba75-59e6655ac7ac" />
<img width="2032" height="1167" alt="스크린샷 2025-07-29 02 58 54" src="https://github.com/user-attachments/assets/f9e19bd4-6c33-46f9-af08-c26b7aa286f6" />
<img width="1920" height="1080" alt="스크린샷 2025-07-29 03 00 05" src="https://github.com/user-attachments/assets/e10f9103-7bf6-4e69-911c-7fbb3a48a44c" />
<img width="2032" height="1167" alt="스크린샷 2025-07-29 02 58 43" src="https://github.com/user-attachments/assets/8fb515ab-9c3d-4637-bbd9-a73a4420ed9f" />
<img width="1920" height="1080" alt="스크린샷 2025-07-29 03 00 14" src="https://github.com/user-attachments/assets/d5dd1276-476d-4aca-a233-ba8f0bc43f2e" />