### PR TITLE
[EA3-204] refactor : 리뷰 작성 시 버디에너지 증가 대상 변경 및 Controller에 ResponseEntity 적용

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/buddy/controller/BuddyEnergyController.java
+++ b/src/main/java/grep/neogulcoder/domain/buddy/controller/BuddyEnergyController.java
@@ -4,6 +4,7 @@ import grep.neogulcoder.domain.buddy.controller.dto.response.BuddyEnergyResponse
 import grep.neogulcoder.domain.buddy.service.BuddyEnergyService;
 import grep.neogulcoder.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -14,8 +15,8 @@ public class BuddyEnergyController implements BuddyEnergySpecification {
     private final BuddyEnergyService buddyEnergyService;
 
     @GetMapping("/{userId}")
-    public ApiResponse<BuddyEnergyResponse> get(@PathVariable("userId") Long userId) {
-        return ApiResponse.success(buddyEnergyService.getBuddyEnergy(userId));
+    public ResponseEntity<ApiResponse<BuddyEnergyResponse>> get(@PathVariable("userId") Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(buddyEnergyService.getBuddyEnergy(userId)));
     }
 
 

--- a/src/main/java/grep/neogulcoder/domain/buddy/controller/BuddyEnergySpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/buddy/controller/BuddyEnergySpecification.java
@@ -3,11 +3,12 @@ package grep.neogulcoder.domain.buddy.controller;
 import grep.neogulcoder.domain.buddy.controller.dto.response.BuddyEnergyResponse;
 import grep.neogulcoder.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
 public interface BuddyEnergySpecification {
 
     @Operation(summary = "버디 에너지 조회", description = "특정 사용자의 버디 에너지를 조회합니다")
-    ApiResponse<BuddyEnergyResponse> get(@PathVariable Long userId);
+    ResponseEntity<ApiResponse<BuddyEnergyResponse>> get(@PathVariable Long userId);
 
 }

--- a/src/main/java/grep/neogulcoder/domain/calendar/controller/PersonalCalendarController.java
+++ b/src/main/java/grep/neogulcoder/domain/calendar/controller/PersonalCalendarController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -20,47 +21,47 @@ public class PersonalCalendarController implements PersonalCalendarSpecification
 
     // 사용자 개인 일정 등록 API
     @PostMapping
-    public ApiResponse<Long> create(
+    public ResponseEntity<ApiResponse<Long>> create(
         @PathVariable("userId") Long userId,
         @Valid @RequestBody PersonalCalendarRequest request) {
         Long personalCalendarId  = personalCalendarService.create(userId, request);
-        return ApiResponse.success(personalCalendarId );  // 생성된 일정 ID 반환
+        return ResponseEntity.ok(ApiResponse.success(personalCalendarId));  // 생성된 일정 ID 반환
     }
 
     // 사용자 개인 일정 전체 조회 API
     @GetMapping
-    public ApiResponse<List<PersonalCalendarResponse>> findAll(@PathVariable("userId") Long userId) {
+    public ResponseEntity<ApiResponse<List<PersonalCalendarResponse>>> findAll(@PathVariable("userId") Long userId) {
         // 해당 userId가 등록한 모든 개인 일정을 조회하여 리스트로 반환
-        return ApiResponse.success(personalCalendarService.findAll(userId));
+        return ResponseEntity.ok(ApiResponse.success(personalCalendarService.findAll(userId)));
     }
 
     // 사용자 특정 날짜의 일정 조회 API
     @GetMapping("/day")
-    public ApiResponse<List<PersonalCalendarResponse>> findByDate(
+    public ResponseEntity<ApiResponse<List<PersonalCalendarResponse>>> findByDate(
         @PathVariable("userId") Long userId,
         @RequestParam String date
     ) {
         LocalDate parsedDate = LocalDate.parse(date); // 문자열을 LocalDate 타입으로 파싱
-        return ApiResponse.success(personalCalendarService.findByDate(userId, parsedDate));
+        return ResponseEntity.ok(ApiResponse.success(personalCalendarService.findByDate(userId, parsedDate)));
     }
 
     @PutMapping("/{personalCalendarId}")
-    public ApiResponse<Void> update(
+    public ResponseEntity<ApiResponse<Void>> update(
         @PathVariable("userId") Long userId,
         @PathVariable("personalCalendarId") Long personalCalendarId,
         @Valid @RequestBody PersonalCalendarRequest request
     ) {
         personalCalendarService.update(userId, personalCalendarId, request);
-        return ApiResponse.noContent();
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     @DeleteMapping("/{personalCalendarId}")
-    public ApiResponse<Void> delete(
+    public ResponseEntity<ApiResponse<Void>> delete(
         @PathVariable("userId") Long userId,
         @PathVariable("personalCalendarId") Long personalCalendarId
     ) {
         personalCalendarService.delete(userId, personalCalendarId);
-        return ApiResponse.noContent();
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 }
 

--- a/src/main/java/grep/neogulcoder/domain/calendar/controller/PersonalCalendarSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/calendar/controller/PersonalCalendarSpecification.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -20,7 +21,7 @@ public interface PersonalCalendarSpecification {
         summary = "개인 일정 생성",
         description = "사용자의 개인 일정을 생성하고, 생성된 개인 일정 ID를 반환합니다. \n\n예: `/api/users/{userId}/calendar`"
     )
-    ApiResponse<Long> create(
+    ResponseEntity<ApiResponse<Long>> create(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("userId") Long userId,
         @RequestBody PersonalCalendarRequest request
@@ -30,7 +31,7 @@ public interface PersonalCalendarSpecification {
         summary = "개인 일정 전체 조회",
         description = "사용자 ID 기준으로 모든 개인 일정을 조회합니다.\n\n예: `/api/users/{userId}/calendar`"
     )
-    ApiResponse<List<PersonalCalendarResponse>> findAll(
+    ResponseEntity<ApiResponse<List<PersonalCalendarResponse>>> findAll(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("userId") Long userId
     );
@@ -40,7 +41,7 @@ public interface PersonalCalendarSpecification {
         description = "특정 사용자 ID와 날짜에 해당하는 모든 개인 일정을 조회합니다.\n\n" +
             "예: `/api/users/{userId}/calendar/day?date=2025-07-17`"
     )
-    ApiResponse<List<PersonalCalendarResponse>> findByDate(
+    ResponseEntity<ApiResponse<List<PersonalCalendarResponse>>> findByDate(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("userId") Long userId,
 
@@ -53,7 +54,7 @@ public interface PersonalCalendarSpecification {
         summary = "개인 일정 수정",
         description = "사용자의 특정 일정을 수정합니다.\n\n예: `/api/users/{userId}/calendar/{personalCalendarId}`"
     )
-    ApiResponse<Void> update(
+    ResponseEntity<ApiResponse<Void>> update(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("userId") Long userId,
 
@@ -67,7 +68,7 @@ public interface PersonalCalendarSpecification {
         summary = "개인 일정 삭제",
         description = "사용자의 특정 일정을 삭제합니다.\n\n예: `/api/users/{userId}/calendar/{personalCalendarId}`"
     )
-    ApiResponse<Void> delete(
+    ResponseEntity<ApiResponse<Void>> delete(
         @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("userId") Long userId,
 

--- a/src/main/java/grep/neogulcoder/domain/calendar/controller/TeamCalendarController.java
+++ b/src/main/java/grep/neogulcoder/domain/calendar/controller/TeamCalendarController.java
@@ -8,6 +8,8 @@ import grep.neogulcoder.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,66 +24,66 @@ public class TeamCalendarController implements TeamCalendarSpecification {
 
     // 팀 일정 생성
     @PostMapping
-    public ApiResponse<Long> create(
+    public ResponseEntity<ApiResponse<Long>> create(
         @AuthenticationPrincipal(expression = "userId") Long userId,              // 인증된 사용자의 ID를 자동 주입받음
         @PathVariable("studyId") Long studyId,
         @Valid @RequestBody TeamCalendarRequest request
     ) {
         Long teamCalendarId = teamCalendarService.create(studyId, userId, request);
-        return ApiResponse.success(teamCalendarId);  // 생성된 일정 ID 반환
+        return ResponseEntity.ok(ApiResponse.success(teamCalendarId));  // 생성된 일정 ID 반환
     }
 
     // 전체 일정 조회 API
     @GetMapping
-    public ApiResponse<List<TeamCalendarResponse>> findAll(
+    public ResponseEntity<ApiResponse<List<TeamCalendarResponse>>> findAll(
         @AuthenticationPrincipal(expression = "userId") Long userId,
         @PathVariable("studyId") Long studyId) {
-        return ApiResponse.success(teamCalendarService.findAll(studyId));
+        return ResponseEntity.ok(ApiResponse.success(teamCalendarService.findAll(studyId)));
     }
 
     // 특정 날짜에 해당하는 팀 일정 조회 API
     @GetMapping("/day")
-    public ApiResponse<List<TeamCalendarResponse>> findByDate(
+    public ResponseEntity<ApiResponse<List<TeamCalendarResponse>>> findByDate(
         @AuthenticationPrincipal(expression = "userId") Long userId,
         @PathVariable("studyId") Long studyId,
         @RequestParam String date
     ) {
         LocalDate parsedDate = LocalDate.parse(date);
-        return ApiResponse.success(teamCalendarService.findByDate(studyId, parsedDate));
+        return ResponseEntity.ok(ApiResponse.success(teamCalendarService.findByDate(studyId, parsedDate)));
     }
 
     // 특정 월(한 달 단위) 팀 일정 조회 API
     @GetMapping("/month")
-    public ApiResponse<List<TeamCalendarResponse>> findByMonth(
+    public ResponseEntity<ApiResponse<List<TeamCalendarResponse>>> findByMonth(
         @AuthenticationPrincipal(expression = "userId") Long userId,
         @PathVariable("studyId") Long studyId,
         @RequestParam int year,
         @RequestParam int month
     ) {
-        return ApiResponse.success(teamCalendarService.findByMonth(studyId, year, month));
+        return ResponseEntity.ok(ApiResponse.success(teamCalendarService.findByMonth(studyId, year, month)));
     }
 
     // 팀 일정 수정 API - 본인이 작성한 일정만 수정 가능
     @PutMapping("/{teamCalendarId}")
-    public ApiResponse<Void> update(
+    public ResponseEntity<ApiResponse<Void>> update(
         @AuthenticationPrincipal(expression = "userId") Long userId,
         @PathVariable("studyId") Long studyId,
         @PathVariable("teamCalendarId") Long teamCalendarId,
         @Valid @RequestBody TeamCalendarRequest request
     ) {
         teamCalendarService.update(studyId, userId, teamCalendarId, request);
-        return ApiResponse.noContent();
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     // 팀 일정 삭제 API - 본인이 작성한 일정만 삭제 가능
     @DeleteMapping("/{teamCalendarId}")
-    public ApiResponse<Void> delete(
+    public ResponseEntity<ApiResponse<Void>> delete(
         @AuthenticationPrincipal(expression = "userId") Long userId,
         @PathVariable("studyId") Long studyId,
         @PathVariable("teamCalendarId") Long teamCalendarId
     ) {
         teamCalendarService.delete(studyId, userId, teamCalendarId);
-        return ApiResponse.noContent();
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 }
 

--- a/src/main/java/grep/neogulcoder/domain/calendar/controller/TeamCalendarSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/calendar/controller/TeamCalendarSpecification.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +23,7 @@ public interface TeamCalendarSpecification {
         description = "특정 팀 ID에 해당하는 모든 일정을 조회합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar`"
     )
-    ApiResponse<List<TeamCalendarResponse>> findAll(
+    ResponseEntity<ApiResponse<List<TeamCalendarResponse>>> findAll(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "조회할 팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId
@@ -33,7 +34,7 @@ public interface TeamCalendarSpecification {
         description = "특정 팀의 특정 날짜(yyyy-MM-dd)에 등록된 일정들을 조회합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar/day?date=2025-07-17`"
     )
-    ApiResponse<List<TeamCalendarResponse>> findByDate(
+    ResponseEntity<ApiResponse<List<TeamCalendarResponse>>> findByDate(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "조회할 팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId,
@@ -47,7 +48,7 @@ public interface TeamCalendarSpecification {
         description = "특정 팀의 특정 월(year, month)에 등록된 모든 일정을 조회합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar/month?year=2025&month=7`"
     )
-    ApiResponse<List<TeamCalendarResponse>> findByMonth(
+    ResponseEntity<ApiResponse<List<TeamCalendarResponse>>> findByMonth(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "조회할 팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId,
@@ -65,7 +66,7 @@ public interface TeamCalendarSpecification {
         description = "팀 일정을 생성하고 생성된 팀 일정 ID를 반환합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar`"
     )
-    ApiResponse<Long> create(
+    ResponseEntity<ApiResponse<Long>> create(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "일정을 생성할 팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId,
@@ -77,7 +78,7 @@ public interface TeamCalendarSpecification {
         description = "기존 팀 일정을 수정합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar/{teamCalendarId}`"
     )
-    ApiResponse<Void> update(
+    ResponseEntity<ApiResponse<Void>> update(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId,
@@ -91,7 +92,7 @@ public interface TeamCalendarSpecification {
         description = "기존 팀 일정을 삭제합니다.\n\n" +
             "예: `/api/teams/{studyId}/calendar/{teamCalendarId}`"
     )
-    ApiResponse<Void> delete(
+    ResponseEntity<ApiResponse<Void>> delete(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
         @Parameter(name = "studyId", description = "팀 ID", required = true, in = ParameterIn.PATH)
         @PathVariable("studyId") Long studyId,

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestController.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestController.java
@@ -6,6 +6,7 @@ import grep.neogulcoder.domain.groupchat.service.GroupChatService;
 import grep.neogulcoder.global.response.ApiResponse;
 import grep.neogulcoder.global.response.PageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,13 +19,13 @@ public class GroupChatRestController implements GroupChatRestSpecification {
     // 과거 채팅 메시지 페이징 조회 (무한 스크롤용)
     @Override
     @GetMapping("/study/{studyId}/messages")
-    public ApiResponse<ChatMessagePagingResponse> getMessages(
+    public ResponseEntity<ApiResponse<ChatMessagePagingResponse>> getMessages(
         @PathVariable("studyId") Long studyId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size
     ) {
         // 서비스에서 페이징된 메시지 조회
         ChatMessagePagingResponse response = groupChatService.getMessages(studyId, page, size);
-        return ApiResponse.success(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatRestSpecification.java
@@ -7,6 +7,7 @@ import grep.neogulcoder.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -73,8 +74,7 @@ public interface GroupChatRestSpecification {
         ```
         """
     )
-
-    ApiResponse<ChatMessagePagingResponse> getMessages(
+    ResponseEntity<ApiResponse<ChatMessagePagingResponse>> getMessages(
         @Parameter(description = "스터디 ID", example = "1")
         @PathVariable("studyId") Long studyId,
 

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerController.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerController.java
@@ -3,6 +3,7 @@ package grep.neogulcoder.domain.groupchat.controller;
 import grep.neogulcoder.domain.groupchat.controller.dto.request.GroupChatSwaggerRequest;
 import grep.neogulcoder.domain.groupchat.controller.dto.response.GroupChatSwaggerResponse;
 import grep.neogulcoder.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,19 +15,19 @@ public class GroupChatSwaggerController implements GroupChatSwaggerSpecification
 
     @PostMapping("/pub/chat/message")
     @Override
-    public ApiResponse<GroupChatSwaggerResponse> sendMessage(
+    public ResponseEntity<ApiResponse<GroupChatSwaggerResponse>> sendMessage(
         @RequestBody GroupChatSwaggerRequest request) {
-        return ApiResponse.success(new GroupChatSwaggerResponse());
+        return ResponseEntity.ok(ApiResponse.success(new GroupChatSwaggerResponse()));
     }
 
 
     @GetMapping("/sub/chat/study/{studyId}")
     @Override
-    public ApiResponse<List<GroupChatSwaggerResponse>> getMessages(@PathVariable Long studyId) {
+    public ResponseEntity<ApiResponse<List<GroupChatSwaggerResponse>>> getMessages(@PathVariable Long studyId) {
         List<GroupChatSwaggerResponse> messages = List.of(
             new GroupChatSwaggerResponse(),
             new GroupChatSwaggerResponse()
         );
-        return ApiResponse.success(messages);
+        return ResponseEntity.ok(ApiResponse.success(messages));
     }
 }

--- a/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/groupchat/controller/GroupChatSwaggerSpecification.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import org.springframework.http.ResponseEntity;
 
 @Tag(name = "GroupChat", description = "WebSocket 구조 설명용 Swagger 문서")
 public interface GroupChatSwaggerSpecification {
@@ -33,7 +34,7 @@ public interface GroupChatSwaggerSpecification {
         ** Swagger에서 이 API를 실행해도 실제 전송은 되지 않으며, 
         WebSocket 통신 구조를 이해하기 위한 문서 예시입니다.**
         """)
-    ApiResponse<GroupChatSwaggerResponse> sendMessage(GroupChatSwaggerRequest request);
+    ResponseEntity<ApiResponse<GroupChatSwaggerResponse>> sendMessage(GroupChatSwaggerRequest request);
 
     @Operation(summary = "채팅 메시지 수신 (WebSocket Sub)",
         description = """
@@ -64,5 +65,5 @@ public interface GroupChatSwaggerSpecification {
         ** Swagger에서는 WebSocket 구독을 테스트할 수 없으며,
         이 문서는 프론트엔드 구현 참고용입니다.**
         """)
-    ApiResponse<List<GroupChatSwaggerResponse>> getMessages(Long studyId);
+    ResponseEntity<ApiResponse<List<GroupChatSwaggerResponse>>> getMessages(Long studyId);
 }

--- a/src/main/java/grep/neogulcoder/domain/review/service/ReviewService.java
+++ b/src/main/java/grep/neogulcoder/domain/review/service/ReviewService.java
@@ -109,7 +109,7 @@ public class ReviewService {
         Review review = request.toReview(reviewTags.getReviewTags(), reviewType, writeUserId);
         List<ReviewTagEntity> reviewTagEntities = mapToReviewTagEntities(reviewTags);
 
-        updatedBuddyEnergy(writeUserId, reviewType);
+        updatedBuddyEnergy(request.getTargetUserId(), reviewType);
         return reviewRepository.save(ReviewEntity.from(review, reviewTagEntities, study.getId())).getId();
     }
 
@@ -201,8 +201,8 @@ public class ReviewService {
         return reviewTagRepository.findByReviewTagIn(reviewTagDescriptions);
     }
 
-    private BuddyEnergy updatedBuddyEnergy(long writeUserId, ReviewType reviewType) {
-        BuddyEnergy energy = buddyEnergyRepository.findByUserId(writeUserId)
+    private BuddyEnergy updatedBuddyEnergy(long targetUserId, ReviewType reviewType) {
+        BuddyEnergy energy = buddyEnergyRepository.findByUserId(targetUserId)
                 .orElseThrow(() -> new BuddyEnergyNotFoundException(BUDDY_ENERGY_NOT_FOUND));
 
         energy.updateEnergy(reviewType);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -150,12 +150,16 @@ INSERT INTO upload_image (origin_file_name, rename_file_name, file_url, save_pat
 INSERT INTO buddy_energy (user_id, level) VALUES (1, 50);
 INSERT INTO buddy_energy (user_id, level) VALUES (2, 53);
 INSERT INTO buddy_energy (user_id, level) VALUES (3, 49);
+INSERT INTO buddy_energy (user_id, level) VALUES (7, 50);
+INSERT INTO buddy_energy (user_id, level) VALUES (8, 50);
 
 -- [ buddy_log ]
 INSERT INTO buddy_log (reason, buddy_energy_id) VALUES ('SIGN_UP', 1);
 INSERT INTO buddy_log (reason, buddy_energy_id) VALUES ('STUDY_DONE', 2);
 INSERT INTO buddy_log (reason, buddy_energy_id) VALUES ('TEAM_LEADER_BONUS', 2);
 INSERT INTO buddy_log (reason, buddy_energy_id) VALUES ('NEGATIVE_REVIEW', 3);
+INSERT INTO buddy_log (reason, buddy_energy_id) VALUES ('SIGN_UP', 4);
+INSERT INTO buddy_log (reason, buddy_energy_id) VALUES ('SIGN_UP', 5);
 
 -- [ pr_template ]
 INSERT INTO pr_template (user_id, introduction, location, activated) VALUES (1, '함께 성장하는 백엔드 개발자입니다. 협업과 커뮤니케이션을 중요하게 생각하며, 문제 해결에 집중하는 개발 문화를 지향합니다.', '서울시 강남구', TRUE);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#279 

## 📌 과제 설명
- 버디에너지 로직 수정 (리뷰 작성자(writeUserId)가 아닌 리뷰 대상자(targetUserId)에 에너지 반영)
- 기존 API 응답 구조에서 ResponseEntity<ApiResponse<>>를 통일적으로 적용하여 응답 일관성을 확보.
- 그룹채팅, 버디에너지, 캘린더(Personal/Team) 모든 도메인의 Controller 리팩토링 진행.

## 👩‍💻 요구 사항과 구현 내용 
**버디에너지 로직 수정**
- 리뷰 작성 시 **리뷰 대상자(targetUserId)**에게 에너지 반영되도록 ReviewService의 updatedBuddyEnergy() 로직 변경.

**ResponseEntity 적용**
- GroupChatRestController, BuddyEnergyController, PersonalCalendarController, TeamCalendarController의 모든 메서드에서 ResponseEntity<ApiResponse<>> 형태로 반환하도록 수정.
- 기존 ApiResponse.success() 및 ApiResponse.noContent()는 그대로 유지하되 ResponseEntity.ok()와 결합.

## ✅ 피드백 반영사항  
**ResponseEntity 활용: 강사님 피드백에 따라 모든 Controller에서 ResponseEntity를 적용하여 HTTP 상태 코드와 ApiResponse의 status 간 불일치를 방지.**

