### PR TITLE
Fix: 회원 탈퇴 시 비밀번호 확인을 체크하지 않던 문제 해결

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogulcoder/domain/users/controller/UserController.java
@@ -78,7 +78,7 @@ public class UserController implements UserSpecification {
     @DeleteMapping("/delete/me")
     public ResponseEntity<ApiResponse<Void>> delete(@AuthenticationPrincipal Principal principal,
         @RequestBody @Valid PasswordRequest request) {
-        usersService.deleteUser(principal.getUserId(), request.getPassword());
+        usersService.deleteUser(principal.getUserId(), request.getPassword(), request.getPasswordCheck());
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 

--- a/src/main/java/grep/neogulcoder/domain/users/controller/dto/request/PasswordRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/users/controller/dto/request/PasswordRequest.java
@@ -9,4 +9,7 @@ public class PasswordRequest {
     @NotBlank(message = "비밀번호를 입력하세요")
     private String password;
 
+    @NotBlank(message = "비밀번호 확인을 입력하세요")
+    private String passwordCheck;
+
 }

--- a/src/main/java/grep/neogulcoder/domain/users/service/UserService.java
+++ b/src/main/java/grep/neogulcoder/domain/users/service/UserService.java
@@ -126,11 +126,15 @@ public class UserService {
         user.updatePassword(encodedPassword);
     }
 
-    public void deleteUser(Long userId, String password) {
+    public void deleteUser(Long userId, String password, String passwordCheck) {
         User user = findUserById(userId);
 
         if (isNotMatchCurrentPassword(password, user.getPassword())) {
             throw new PasswordNotMatchException(UserErrorCode.PASSWORD_MISMATCH);
+        }
+
+        if(isNotMatchPasswordCheck(password, passwordCheck)) {
+            throw new PasswordNotMatchException(UserErrorCode.PASSWORD_UNCHECKED);
         }
 
         studyManagementService.deleteUserFromStudies(userId);


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

회원 탈퇴 시 비밀번호 확인을 잘못 입력해도 탈퇴되던 문제 해결

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

회원 탈퇴 시 비밀번호 확인을 잘못 입력해도 탈퇴되던 문제 해결