### PR TITLE
Fix: 회원이 탈퇴한 경우에 OAuth 로그인으로 로그인하지 못하도록 수정

### DIFF
--- a/src/main/java/grep/neogulcoder/global/auth/service/AuthService.java
+++ b/src/main/java/grep/neogulcoder/global/auth/service/AuthService.java
@@ -92,7 +92,12 @@ public class AuthService {
         String dummyPassword = UUID.randomUUID().toString();
 
         return usersRepository.findByEmail(email)
-            .map(user -> processTokenSignin(user.getEmail(), user.getRole().name()))
+            .map(user -> {
+                if (!user.isActivated()) {
+                    throw new UnActivatedUserException(UserErrorCode.UNACTIVATED_USER);
+                }
+                return processTokenSignin(user.getEmail(), user.getRole().name());
+            })
             .orElseGet(() -> {
                 User newUser = User.builder()
                     .email(email)


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

OAuth로그인 시 탈퇴된 이메일로 가입한 회원이면 예외를 던지도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

OAuth로그인 시 탈퇴된 이메일로 가입한 회원이면 예외를 던지도록 수정
