### PR TITLE
refactor: 모집글 검색 Method Rename

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/recruitment/post/controller/RecruitmentPostController.java
+++ b/src/main/java/grep/neogulcoder/domain/recruitment/post/controller/RecruitmentPostController.java
@@ -25,23 +25,23 @@ public class RecruitmentPostController implements RecruitmentPostSpecification {
     private final RecruitmentPostService recruitmentPostService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> getPagingInfo(@PageableDefault(size = 10) Pageable pageable,
-                                                                               @RequestParam(value = "category", required = false) Category category,
-                                                                               @RequestParam(value = "studyType", required = false) StudyType studyType,
-                                                                               @RequestParam(value = "keyword", required = false) String keyword) {
-        RecruitmentPostPagingInfo response = recruitmentPostService.getPagingInfo(
+    public ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> search(@PageableDefault(size = 10) Pageable pageable,
+                                                                         @RequestParam(value = "category", required = false) Category category,
+                                                                         @RequestParam(value = "studyType", required = false) StudyType studyType,
+                                                                         @RequestParam(value = "keyword", required = false) String keyword) {
+        RecruitmentPostPagingInfo response = recruitmentPostService.search(
                 pageable, category, studyType, keyword, null
         );
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> getMyPostPagingInfo(@PageableDefault(size = 10) Pageable pageable,
-                                                                      @RequestParam(value = "category", required = false) Category category,
-                                                                      @RequestParam(value = "studyType", required = false) StudyType studyType,
-                                                                      @RequestParam(value = "keyword", required = false) String keyword,
-                                                                      @AuthenticationPrincipal Principal userDetails) {
-        RecruitmentPostPagingInfo response = recruitmentPostService.getPagingInfo(
+    public ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> searchMyRecruitmentPost(@PageableDefault(size = 10) Pageable pageable,
+                                                                                          @RequestParam(value = "category", required = false) Category category,
+                                                                                          @RequestParam(value = "studyType", required = false) StudyType studyType,
+                                                                                          @RequestParam(value = "keyword", required = false) String keyword,
+                                                                                          @AuthenticationPrincipal Principal userDetails) {
+        RecruitmentPostPagingInfo response = recruitmentPostService.search(
                 pageable, category, studyType,
                 keyword, userDetails.getUserId()
         );
@@ -56,23 +56,23 @@ public class RecruitmentPostController implements RecruitmentPostSpecification {
 
     @PutMapping("/{recruitment-post-id}")
     public ResponseEntity<ApiResponse<Long>> update(@PathVariable("recruitment-post-id") long recruitmentPostId,
-                                    @Valid @RequestBody RecruitmentPostUpdateRequest request,
-                                    @AuthenticationPrincipal Principal userDetails) {
+                                                    @Valid @RequestBody RecruitmentPostUpdateRequest request,
+                                                    @AuthenticationPrincipal Principal userDetails) {
         long postId = recruitmentPostService.update(request.toServiceRequest(), recruitmentPostId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.success(postId));
     }
 
     @DeleteMapping("/{recruitment-post-id}")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable("recruitment-post-id") long recruitmentPostId,
-                                    @AuthenticationPrincipal Principal userDetails) {
+                                                    @AuthenticationPrincipal Principal userDetails) {
         recruitmentPostService.delete(recruitmentPostId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     @PutMapping("/{recruitment-post-id}/status")
     public ResponseEntity<ApiResponse<Long>> changeStatus(@PathVariable("recruitment-post-id") long recruitmentPostId,
-                                          @RequestBody RecruitmentPostStatusUpdateRequest request,
-                                          @AuthenticationPrincipal Principal userDetails) {
+                                                          @RequestBody RecruitmentPostStatusUpdateRequest request,
+                                                          @AuthenticationPrincipal Principal userDetails) {
         long postId = recruitmentPostService.updateStatus(request.toServiceRequest(), recruitmentPostId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.success(postId));
     }

--- a/src/main/java/grep/neogulcoder/domain/recruitment/post/controller/RecruitmentPostSpecification.java
+++ b/src/main/java/grep/neogulcoder/domain/recruitment/post/controller/RecruitmentPostSpecification.java
@@ -84,8 +84,8 @@ public interface RecruitmentPostSpecification {
                     ```
                     """
     )
-    ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> getMyPostPagingInfo(Pageable pageable, Category category, StudyType studyType,
-                                                               String keyword, Principal userDetails);
+    ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> searchMyRecruitmentPost(Pageable pageable, Category category, StudyType studyType,
+                                                                                   String keyword, Principal userDetails);
 
     @Operation(
             summary = "모집글 페이징 조회",
@@ -143,5 +143,5 @@ public interface RecruitmentPostSpecification {
                     ```
                     """
     )
-    ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> getPagingInfo(Pageable pageable, Category category, StudyType studyType, String keyword);
+    ResponseEntity<ApiResponse<RecruitmentPostPagingInfo>> search(Pageable pageable, Category category, StudyType studyType, String keyword);
 }

--- a/src/main/java/grep/neogulcoder/domain/recruitment/post/repository/RecruitmentPostQueryRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/recruitment/post/repository/RecruitmentPostQueryRepository.java
@@ -62,7 +62,7 @@ public class RecruitmentPostQueryRepository {
                 ).fetchOne();
     }
 
-    public Page<RecruitmentPost> findAllByFilter(Pageable pageable, Category category, StudyType studyType, String keyword) {
+    public Page<RecruitmentPost> search(Pageable pageable, Category category, StudyType studyType, String keyword) {
         List<RecruitmentPost> content = queryFactory.select(recruitmentPost)
                 .from(recruitmentPost)
                 .join(study).on(recruitmentPost.studyId.eq(study.id))
@@ -93,7 +93,7 @@ public class RecruitmentPostQueryRepository {
         return new PageImpl<>(content, pageable, count == null ? 0 : count);
     }
 
-    public Page<RecruitmentPost> findAllByFilter(Pageable pageable, Category category, StudyType studyType, String keyword, Long userId) {
+    public Page<RecruitmentPost> search(Pageable pageable, Category category, StudyType studyType, String keyword, Long userId) {
         List<RecruitmentPost> content = queryFactory.select(recruitmentPost)
                 .from(recruitmentPost)
                 .join(study).on(recruitmentPost.studyId.eq(study.id))
@@ -125,17 +125,6 @@ public class RecruitmentPostQueryRepository {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, count == null ? 0 : count);
-    }
-
-    public Optional<RecruitmentPost> findMyPostBy(long postId, long userId) {
-        RecruitmentPost findRecruitmentPost = queryFactory.selectFrom(recruitmentPost)
-                .where(
-                        recruitmentPost.activated.isTrue(),
-                        recruitmentPost.userId.eq(userId),
-                        recruitmentPost.id.eq(postId)
-                )
-                .fetchOne();
-        return Optional.ofNullable(findRecruitmentPost);
     }
 
     public Optional<RecruitmentPost> findPostBy(long postId) {

--- a/src/main/java/grep/neogulcoder/domain/recruitment/post/service/RecruitmentPostService.java
+++ b/src/main/java/grep/neogulcoder/domain/recruitment/post/service/RecruitmentPostService.java
@@ -56,8 +56,8 @@ public class RecruitmentPostService {
         return new RecruitmentPostInfo(postInfo, comments, applications.size());
     }
 
-    public RecruitmentPostPagingInfo getPagingInfo(Pageable pageable, Category category, StudyType studyType, String keyword, Long userId) {
-        Page<RecruitmentPost> pages = findPostsFilteredByUser(pageable, category, studyType, keyword, userId);
+    public RecruitmentPostPagingInfo search(Pageable pageable, Category category, StudyType studyType, String keyword, Long userId) {
+        Page<RecruitmentPost> pages = searchRecruitmentPost(pageable, category, studyType, keyword, userId);
         List<RecruitmentPost> content = pages.getContent();
         List<Long> recruitmentPostIds = extractId(content);
 
@@ -105,12 +105,12 @@ public class RecruitmentPostService {
         return applyWithdrawnUserNameChanges(comments, withdrawnUserComments);
     }
 
-    private Page<RecruitmentPost> findPostsFilteredByUser(Pageable pageable, Category category, StudyType studyType,
-                                                          String keyword, Long userId) {
+    private Page<RecruitmentPost> searchRecruitmentPost(Pageable pageable, Category category, StudyType studyType,
+                                                        String keyword, Long userId) {
         if (userId == null) {
-            return postQueryRepository.findAllByFilter(pageable, category, studyType, keyword);
+            return postQueryRepository.search(pageable, category, studyType, keyword);
         }
-        return postQueryRepository.findAllByFilter(pageable, category, studyType, keyword, userId);
+        return postQueryRepository.search(pageable, category, studyType, keyword, userId);
     }
 
     private List<CommentsWithWriterInfo> withdrawnUserChangeNameFrom(List<CommentsWithWriterInfo> comments) {

--- a/src/main/java/grep/neogulcoder/domain/study/controller/StudyController.java
+++ b/src/main/java/grep/neogulcoder/domain/study/controller/StudyController.java
@@ -58,38 +58,38 @@ public class StudyController implements StudySpecification {
 
     @GetMapping("/{studyId}/info")
     public ResponseEntity<ApiResponse<StudyInfoResponse>> getStudyInfo(@PathVariable("studyId") Long studyId,
-                                                       @AuthenticationPrincipal Principal userDetails) {
+                                                                       @AuthenticationPrincipal Principal userDetails) {
         Long userId = userDetails.getUserId();
         return ResponseEntity.ok(ApiResponse.success(studyService.getMyStudyContent(studyId, userId)));
     }
 
     @GetMapping("/{studyId}/me")
     public ResponseEntity<ApiResponse<StudyMemberInfoResponse>> getMyStudyMemberInfo(@PathVariable("studyId") Long studyId,
-                                                                     @AuthenticationPrincipal Principal userDetails) {
+                                                                                     @AuthenticationPrincipal Principal userDetails) {
         Long userId = userDetails.getUserId();
         return ResponseEntity.ok(ApiResponse.success(studyService.getMyStudyMemberInfo(studyId, userId)));
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createStudy(@RequestPart("request") @Valid StudyCreateRequest request,
-                                         @RequestPart(value = "image", required = false) MultipartFile image,
-                                         @AuthenticationPrincipal Principal userDetails) throws IOException {
+                                                         @RequestPart(value = "image", required = false) MultipartFile image,
+                                                         @AuthenticationPrincipal Principal userDetails) throws IOException {
         Long id = studyService.createStudy(request, userDetails.getUserId(), image);
         return ResponseEntity.ok(ApiResponse.success(id));
     }
 
     @PutMapping(value = "/{studyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> updateStudy(@PathVariable("studyId") Long studyId,
-                                         @RequestPart @Valid StudyUpdateRequest request,
-                                         @RequestPart(value = "image", required = false) MultipartFile image,
-                                         @AuthenticationPrincipal Principal userDetails) throws IOException {
+                                                         @RequestPart @Valid StudyUpdateRequest request,
+                                                         @RequestPart(value = "image", required = false) MultipartFile image,
+                                                         @AuthenticationPrincipal Principal userDetails) throws IOException {
         studyService.updateStudy(studyId, request, userDetails.getUserId(), image);
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     @DeleteMapping("/{studyId}")
     public ResponseEntity<ApiResponse<Void>> deleteStudy(@PathVariable("studyId") Long studyId,
-                                         @AuthenticationPrincipal Principal userDetails) {
+                                                         @AuthenticationPrincipal Principal userDetails) {
         studyService.deleteStudy(studyId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.noContent());
     }

--- a/src/test/java/grep/neogulcoder/domain/recruitment/post/service/RecruitmentPostServiceTest.java
+++ b/src/test/java/grep/neogulcoder/domain/recruitment/post/service/RecruitmentPostServiceTest.java
@@ -158,7 +158,7 @@ class RecruitmentPostServiceTest extends IntegrationTestSupport {
 
     @DisplayName("모집글과 관련된 정보들을 페이징 조회 합니다.")
     @Test
-    void getPagingInfo() {
+    void search() {
         //given
         Study study1 = createStudy("자바 스터디", Category.IT, ONLINE);
         Study study2 = createStudy("클라이밍 동아리", Category.HOBBY, OFFLINE);
@@ -176,7 +176,7 @@ class RecruitmentPostServiceTest extends IntegrationTestSupport {
         commentRepository.saveAll(comments);
 
         //when
-        RecruitmentPostPagingInfo result = recruitmentPostService.getPagingInfo(PageRequest.of(0, 2),
+        RecruitmentPostPagingInfo result = recruitmentPostService.search(PageRequest.of(0, 2),
                 Category.IT, ONLINE, null, null);
         System.out.println("result = " + result);
 
@@ -190,7 +190,7 @@ class RecruitmentPostServiceTest extends IntegrationTestSupport {
 
     @DisplayName("내가 작성한 모집글과 관련된 정보들을 페이징 조회 합니다.")
     @Test
-    void getPagingInfo_WhenWrittenByUser() {
+    void search_WhenWrittenByUser() {
         //given
         User myUser = createUser("myNickname");
         User user2 = createUser("회원");
@@ -213,7 +213,7 @@ class RecruitmentPostServiceTest extends IntegrationTestSupport {
         commentRepository.saveAll(comments);
 
         //when
-        RecruitmentPostPagingInfo result = recruitmentPostService.getPagingInfo(PageRequest.of(0, 2),
+        RecruitmentPostPagingInfo result = recruitmentPostService.search(PageRequest.of(0, 2),
                 Category.HOBBY, OFFLINE, null, myUser.getId());
         System.out.println("result = " + result);
 


### PR DESCRIPTION
## 📌 과제 설명 
- 모집글 검색 메소드 이름 재 정의

## 👩‍💻 요구 사항과 구현 내용
### [ 모집글 검색 메소드 이름 재 정의 ]
- getPagingInfo To search / getMyPostPagingInfo To searchMyRecruitmentPost
- 페이징 보다 검색 한다는 정보가 더 중요하고 직관적이기 때문에 변경
