### PR TITLE
fix: 메일 전송 시 이메일 중복 체크 제외

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/users/service/MailService.java
+++ b/src/main/java/grep/neogulcoder/domain/users/service/MailService.java
@@ -44,10 +44,6 @@ public class MailService {
 
     @Async("mailExecutor")
     public void sendCodeTo(String email, LocalDateTime currentDateTime) {
-        if (isDuplicateEmail(email)) {
-            throw new EmailDuplicationException(UserErrorCode.IS_DUPLICATED_MALI);
-        }
-
         LocalDateTime expiredDateTime = currentDateTime.plusMinutes(VERIFY_LIMIT_MINUTE);
         emailExpiredTimeMap.put(email, expiredDateTime);
         sendCodeTo(email);


### PR DESCRIPTION
## 📌 과제 설명

## 👩‍💻 요구 사항과 구현 내용 
### [ 메일 전송 시 이메일 중복 체크 제외 ]
- 비동기 메일 전송 시 이메일 중복 체크 예외를 처리할 수 없기 때문에 제외
- 회원 가입 할때 중복된 이메일 체크