### PR TITLE
fix: 메일 전송 인증 오류 수정

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/users/controller/UserController.java
+++ b/src/main/java/grep/neogulcoder/domain/users/controller/UserController.java
@@ -94,8 +94,8 @@ public class UserController implements UserSpecification {
     @PostMapping("/mail/verify")
     public ResponseEntity<ApiResponse<Boolean>> verifyCode(@Valid @RequestBody EmailVerifyRequest request) {
         LocalDateTime currentDateTime = LocalDateTime.now();
-        boolean verified = mailService.verifyEmailCode(request.getEmail(), currentDateTime);
-        return ResponseEntity.ok(ApiResponse.success(verified));
+        boolean verified = mailService.verifyEmailCode(request, currentDateTime);
+        return ResponseEntity.ok(ApiResponse.success("인증 성공 여부", verified));
     }
 
     private boolean isNotMatchPassword(String password, String passwordCheck) {

--- a/src/main/java/grep/neogulcoder/domain/users/controller/dto/request/EmailVerifyRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/users/controller/dto/request/EmailVerifyRequest.java
@@ -2,6 +2,7 @@ package grep.neogulcoder.domain.users.controller.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -11,6 +12,22 @@ public class EmailVerifyRequest {
     @Email(message = "올바른 이메일 형식이어야 합니다")
     private String email;
 
+    @NotBlank(message = "인증코드는 필수입니다")
+    private String code;
+
     public EmailVerifyRequest() {
+    }
+
+    @Builder
+    private EmailVerifyRequest(String email, String code) {
+        this.email = email;
+        this.code = code;
+    }
+
+    public static EmailVerifyRequest of(String email, String code){
+        return EmailVerifyRequest.builder()
+                .email(email)
+                .code(code)
+                .build();
     }
 }

--- a/src/main/java/grep/neogulcoder/global/response/ApiResponse.java
+++ b/src/main/java/grep/neogulcoder/global/response/ApiResponse.java
@@ -25,6 +25,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(CommonCode.BAD_REQUEST.getCode(), message, null);
     }
 
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.of(CommonCode.OK.getCode(), message, data);
+    }
+
     public static <T> ApiResponse<T> success(T data) {
         return ApiResponse.of(CommonCode.OK.getCode(), CommonCode.OK.getMessage(), data);
     }
@@ -33,20 +37,12 @@ public class ApiResponse<T> {
         return ApiResponse.of(CommonCode.OK.getCode(), message, null);
     }
 
-    public static <T> ApiResponse<T> successWithCode(T data){
-        return ApiResponse.of(CommonCode.OK.getCode(), CommonCode.OK.getMessage(), data);
-    }
-
     public static <T> ApiResponse<T> noContent(){
         return ApiResponse.of(CommonCode.NO_CONTENT.getCode(), CommonCode.NO_CONTENT.getMessage(), null);
     }
 
     public static <T> ApiResponse<T> create(){
         return ApiResponse.of(CommonCode.CREATED.getCode(), CommonCode.CREATED.getMessage(), null);
-    }
-
-    public static <T> ApiResponse<T> badRequest() {
-        return ApiResponse.of(CommonCode.BAD_REQUEST.getCode(), CommonCode.BAD_REQUEST.getMessage(), null);
     }
 
     public static <T> ApiResponse<T> errorWithoutData(Code code) {


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용 
- 문제: 메일 인증 코드 전송 시 검증 Map 컬렉션에 이메일만 있었던 문제
- 수정: 메일 인증 코드 전송 후 검증 객체( 이메일, 코드 ) 객체 저장

---
## ✅ 메일 검증
### [ 성공 시 ]
<img width="276" height="114" alt="image" src="https://github.com/user-attachments/assets/e5ebc24a-5e17-4008-b407-ea3a670a221d" />

---
### [ 실패 시 ]
<img width="312" height="123" alt="image" src="https://github.com/user-attachments/assets/0468f815-ad2f-43e9-8c29-a88dee20ff11" />