### PR TITLE
feat: 모집글 검색 FullText Index 적용

### DIFF
--- a/src/main/java/grep/neogulcoder/global/config/mysql/FullTextFunction.java
+++ b/src/main/java/grep/neogulcoder/global/config/mysql/FullTextFunction.java
@@ -1,0 +1,35 @@
+package grep.neogulcoder.global.config.mysql;
+
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.query.ReturnableType;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.BasicTypeReference;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+
+public class FullTextFunction extends StandardSQLFunction {
+
+    private static final BasicTypeReference<Double> RETURN_TYPE = new BasicTypeReference<>("double", Double.class, SqlTypes.DOUBLE);
+
+    public FullTextFunction(String name) {
+        super(name, true, RETURN_TYPE);
+    }
+
+    @Override
+    public void render(SqlAppender sqlAppender, List<? extends SqlAstNode> sqlAstArguments, ReturnableType<?> returnType, SqlAstTranslator<?> translator) {
+        if (sqlAstArguments.size() != 3) {
+            throw new IllegalArgumentException("requires exactly 3 arguments");
+        }
+
+        sqlAppender.append("MATCH(");
+        sqlAstArguments.get(0).accept(translator); // 첫번째 인자: 검색 대상 컬럼
+        sqlAppender.append(", ");
+        sqlAstArguments.get(1).accept(translator); // 두번째 인자: 또 다른 컬럼
+        sqlAppender.append(") AGAINST (");
+        sqlAstArguments.get(2).accept(translator); // 세번째 인자: 검색 키워드
+        sqlAppender.append(" IN NATURAL LANGUAGE MODE)");
+    }
+}

--- a/src/main/java/grep/neogulcoder/global/config/mysql/MySqlContributor.java
+++ b/src/main/java/grep/neogulcoder/global/config/mysql/MySqlContributor.java
@@ -1,0 +1,21 @@
+package grep.neogulcoder.global.config.mysql;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MySqlContributor implements FunctionContributor {
+
+    public static final String FUNCTION_NAME = "match";
+    public static final String FUNCTION_PATTERN = "match (?1, ?2) against (?3 IN NATURAL LANGUAGE MODE)";
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry().registerPattern(
+                FUNCTION_NAME, FUNCTION_PATTERN,
+                functionContributions.getTypeConfiguration()
+                        .getBasicTypeRegistry()
+                        .resolve(StandardBasicTypes.DOUBLE)
+        );
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+grep.neogulcoder.global.config.mysql.MySqlContributor


### PR DESCRIPTION
## 📌 과제 설명
- 모집글 검색 FullText Index 적용

---
## 👩‍💻 요구 사항과 구현 내용 
### [ 기존 ] 
- 제목 혹은 내용에 검색어를 포함한 모집글 검색
- LIKE '%검색어%' 방식은 문자열 일치만 가능
- 예시: "Hello world" 검색 시 hello 혹은 world는 검색 불가능

### [ 개선 ]
- 자연어 검색 적용 ( 많이 일치 하는 순서로 검색 결과 반환 )
- 예시: " Hello world "검색 시 hello 혹은 world 내용만 있어도 검색 가능
- 검색어 완전 일치 하지 않더라도 일치율 따라 정렬 제공
- 사용자 경험 개선
---
## ✅ 검색 결과
### [ 기본 검색 ]
![쿼리](https://github.com/user-attachments/assets/46e801cd-4ead-4bcf-a18a-bc8fcc6b24bd)

### [ 결과 ]
![검색결과](https://github.com/user-attachments/assets/8a7181df-2864-4344-96a4-653583a97421)

---
### [ 없는 단어 검색 ]
![없는단어](https://github.com/user-attachments/assets/77b6cfcb-90ce-4080-86c8-4d10cdb71112)

### [ 결과 ]
![결과](https://github.com/user-attachments/assets/e158bcd6-b469-49ff-9d31-8874a7fb2be6)

---
### [ 다중 조건 검색 ]
![다중 조건](https://github.com/user-attachments/assets/aaab8dfc-d0f6-408e-8e8f-a5c5c64c6159)

### [ 결과 ]
![다중조건 결과](https://github.com/user-attachments/assets/75a37584-cea8-4e30-b0e9-77672b402638)

---
### 📝 [ 블로그 정리 ]
- https://heedb.tistory.com/69