### PR TITLE
refactor : 최적 시간 투표 API를 비트마스크 포맷으로 리팩터링

### DIFF
--- a/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteCreateRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteCreateRequest.java
@@ -7,21 +7,30 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
+import static grep.neogulcoder.domain.timevote.provider.TimeSlotBitmaskConverter.expand;
+
 @Getter
 @Schema(description = "스터디 모임 일정 조율 - 가능 시간 제출 요청 DTO")
 public class TimeVoteCreateRequest {
 
-  @NotEmpty(message = "시간대를 1개 이상 선택해주세요.")
+  @NotEmpty(message = "시간대는 최소 한 개 이상의 일자 정보를 포함해야 합니다.")
   @Schema(
-      description = "시간대 리스트",
-      example = "[\"2025-07-25T10:00:00\", \"2025-07-26T11:00:00\"]"
+      description = "일자별 시간 bitmask 리스트 (LSB=0시, 1시간 단위)",
+      example = "[" +
+          "{\"date\": \"2025-08-11\", \"timeMask\": 10}," +
+          "{\"date\": \"2025-08-12\", \"timeMask\": 384}" +
+          "]"
   )
-  private List<LocalDateTime> timeSlots;
+  private List<TimeVoteDateMaskRequest> timeMasks;
 
   private TimeVoteCreateRequest() {}
 
   @Builder
-  private TimeVoteCreateRequest(List<LocalDateTime> timeSlots) {
-    this.timeSlots = timeSlots;
+  private TimeVoteCreateRequest(List<TimeVoteDateMaskRequest> timeMasks) {
+    this.timeMasks = timeMasks;
+  }
+
+  public List<LocalDateTime> toTimeSlots() {
+    return expand(timeMasks);
   }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteDateMaskRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteDateMaskRequest.java
@@ -1,0 +1,33 @@
+package grep.neogulcoder.domain.timevote.dto.request;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "단일 일자에 대한 시간대 비트마스크 DTO")
+public class TimeVoteDateMaskRequest {
+
+  @NotNull(message = "날짜는 비어 있을 수 없습니다.")
+  @Schema(description = "투표 일자", example = "2025-08-11")
+  private LocalDate date;
+
+  @NotNull(message = "시간 비트마스크는 비어 있을 수 없습니다.")
+  @Schema(
+      description = "시간 비트마스크 (LSB=0시, 1시간 단위, 10진수 표현)",
+      example = "1024"
+  )
+  private Long timeMask;
+
+  @Builder
+  private TimeVoteDateMaskRequest(LocalDate date, Long timeMask) {
+    this.date = date;
+    this.timeMask = timeMask;
+  }
+}

--- a/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteDateMaskRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteDateMaskRequest.java
@@ -1,7 +1,6 @@
 package grep.neogulcoder.domain.timevote.dto.request;
 
 import java.time.LocalDate;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteUpdateRequest.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/dto/request/TimeVoteUpdateRequest.java
@@ -7,21 +7,30 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
+import static grep.neogulcoder.domain.timevote.provider.TimeSlotBitmaskConverter.expand;
+
 @Getter
 @Schema(description = "스터디 모임 일정 조율 - 가능 시간 수정 요청 DTO")
 public class TimeVoteUpdateRequest {
 
-  @NotEmpty(message = "시간대를 1개 이상 선택해주세요.")
+  @NotEmpty(message = "시간대는 최소 한 개 이상의 일자 정보를 포함해야 합니다.")
   @Schema(
-      description = "시간대 리스트",
-      example = "[\"2025-07-27T10:00:00\", \"2025-07-28T11:00:00\"]"
+      description = "일자별 시간 비트마스크 리스트 (LSB=0시, 1시간 단위)",
+      example = "[" +
+          "{\"date\": \"2025-08-11\", \"timeMask\": 10}," +
+          "{\"date\": \"2025-08-12\", \"timeMask\": 384}" +
+          "]"
   )
-  private List<LocalDateTime> timeSlots;
+  private List<TimeVoteDateMaskRequest> timeMasks;
 
   private TimeVoteUpdateRequest() {}
 
   @Builder
-  private TimeVoteUpdateRequest( List<LocalDateTime> timeSlots) {
-    this.timeSlots = timeSlots;
+  private TimeVoteUpdateRequest(List<TimeVoteDateMaskRequest> timeMasks) {
+    this.timeMasks = timeMasks;
+  }
+
+  public List<LocalDateTime> toTimeSlots() {
+    return expand(timeMasks);
   }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/dto/response/TimeVoteResponse.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/dto/response/TimeVoteResponse.java
@@ -1,9 +1,13 @@
 package grep.neogulcoder.domain.timevote.dto.response;
 
+import static grep.neogulcoder.domain.timevote.provider.TimeSlotBitmaskConverter.compress;
+
 import grep.neogulcoder.domain.timevote.TimeVote;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,15 +20,22 @@ public class TimeVoteResponse {
   private Long studyMemberId;
 
   @Schema(
-      description = "시간대 리스트",
-      example = "[\"2025-07-26T10:00:00\", \"2025-07-26T11:00:00\", \"2025-07-26T13:00:00\", \"2025-07-28T11:00:00\"]"
+      description = "사용자가 제출한 개별 시간대 리스트",
+      example = "[\"2025-07-26T10:00:00\", \"2025-07-26T11:00:00\"]"
   )
   private List<LocalDateTime> timeSlots;
 
+  @Schema(
+      description = "일자별 시간 비트마스크 (LSB=0시, 1시간 단위)",
+      example = "{\"2025-07-26\": 3, \"2025-07-27\": 384}"
+  )
+  private Map<LocalDate, Long> timeMasks;
+
   @Builder
-  private TimeVoteResponse(Long studyMemberId, List<LocalDateTime> timeSlots) {
+  private TimeVoteResponse(Long studyMemberId, List<LocalDateTime> timeSlots, Map<LocalDate, Long> timeMasks) {
     this.studyMemberId = studyMemberId;
     this.timeSlots = timeSlots;
+    this.timeMasks = timeMasks;
   }
 
   public static TimeVoteResponse from(Long studyMemberId, List<TimeVote> votes) {
@@ -32,9 +43,12 @@ public class TimeVoteResponse {
         .map(TimeVote::getTimeSlot)
         .collect(Collectors.toList());
 
+    Map<LocalDate, Long> timeMasks = compress(votes);
+
     return TimeVoteResponse.builder()
         .studyMemberId(studyMemberId)
         .timeSlots(timeSlots)
+        .timeMasks(timeMasks)
         .build();
   }
 }

--- a/src/main/java/grep/neogulcoder/domain/timevote/exception/code/TimeVoteErrorCode.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/exception/code/TimeVoteErrorCode.java
@@ -28,6 +28,7 @@ public enum TimeVoteErrorCode implements ErrorCode {
   TIME_VOTE_DUPLICATED_TIME_SLOT("TV_003", HttpStatus.BAD_REQUEST, "중복된 시간이 포함되어 있습니다."),
   TIME_VOTE_PERIOD_EXPIRED("TV_004", HttpStatus.BAD_REQUEST, "투표 기간이 만료되었습니다."),
   TIME_VOTE_EMPTY("TV_005", HttpStatus.BAD_REQUEST, "한 개 이상의 시간을 선택해주세요."),
+  TIME_VOTE_INVALID_TIME_MASK("TV_006", HttpStatus.BAD_REQUEST, "시간 비트마스크 값이 유효하지 않습니다."),
 
   // Time Vote Stats (e.g. 통계 충돌 등)
   TIME_VOTE_STAT_CONFLICT("TVS_001", HttpStatus.CONFLICT, "투표 통계 저장 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),

--- a/src/main/java/grep/neogulcoder/domain/timevote/provider/TimeSlotBitmaskConverter.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/provider/TimeSlotBitmaskConverter.java
@@ -1,0 +1,80 @@
+package grep.neogulcoder.domain.timevote.provider;
+
+import static grep.neogulcoder.domain.timevote.exception.code.TimeVoteErrorCode.TIME_VOTE_INVALID_TIME_MASK;
+
+import grep.neogulcoder.domain.timevote.TimeVote;
+import grep.neogulcoder.domain.timevote.dto.request.TimeVoteDateMaskRequest;
+import grep.neogulcoder.global.exception.business.BusinessException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public final class TimeSlotBitmaskConverter {
+
+  private static final int HOURS_PER_DAY = 24;
+  private static final long VALID_MASK_RANGE = (1L << HOURS_PER_DAY) - 1;
+
+  private TimeSlotBitmaskConverter() {}
+
+  // 비트마스크 형식의 시간 정보를 개별 LocalDateTime 리스트로 확장
+  public static List<LocalDateTime> expand(List<TimeVoteDateMaskRequest> masks) {
+    if (masks == null || masks.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<LocalDateTime> timeSlots = new ArrayList<>();
+
+    for (TimeVoteDateMaskRequest request : masks) {
+      if (request.getDate() == null || request.getTimeMask() == null) {
+        throw new BusinessException(TIME_VOTE_INVALID_TIME_MASK);
+      }
+
+      long mask = request.getTimeMask();
+      validateMask(mask);
+
+      LocalDate date = request.getDate();
+      for (int hour = 0; hour < HOURS_PER_DAY; hour++) {
+        if ((mask & (1L << hour)) != 0) {
+          timeSlots.add(date.atTime(hour, 0));
+        }
+      }
+    }
+
+    Collections.sort(timeSlots);
+    return timeSlots;
+  }
+
+  // 개별 TimeVote 객체 리스트를 날짜별 비트마스크로 압축
+  public static Map<LocalDate, Long> compress(List<TimeVote> votes) {
+    if (votes == null || votes.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<LocalDate, Long> compressed = new TreeMap<>();
+
+    for (TimeVote vote : votes) {
+      LocalDateTime timeSlot = vote.getTimeSlot();
+      LocalDate date = timeSlot.toLocalDate();
+      int hour = timeSlot.getHour();
+
+      if (hour < 0 || hour >= HOURS_PER_DAY) {
+        throw new BusinessException(TIME_VOTE_INVALID_TIME_MASK);
+      }
+
+      long bit = 1L << hour;
+      compressed.merge(date, bit, (prev, curr) -> prev | curr);
+    }
+
+    return compressed;
+  }
+
+  private static void validateMask(long mask) {
+    if (mask < 0 || (mask & ~VALID_MASK_RANGE) != 0) {
+      throw new BusinessException(TIME_VOTE_INVALID_TIME_MASK);
+    }
+  }
+}

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteRepository.java
@@ -11,7 +11,13 @@ import org.springframework.data.repository.query.Param;
 public interface TimeVoteRepository extends JpaRepository<TimeVote, Long> {
 
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE TimeVote v SET v.activated = false WHERE v.period.studyId = :studyId")
+  @Query(
+      value =
+          "UPDATE time_vote tv "
+              + "JOIN time_vote_period p ON p.period_id = tv.period_id "
+              + "SET tv.activated = false "
+              + "WHERE p.study_id = :studyId",
+      nativeQuery = true)
   void deactivateAllByPeriod_StudyId(@Param("studyId") Long studyId);
 
   List<TimeVote> findByPeriodAndStudyMemberIdAndActivatedTrue(TimeVotePeriod period, Long studyMemberId);

--- a/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteStatRepository.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/repository/TimeVoteStatRepository.java
@@ -12,7 +12,13 @@ import org.springframework.data.repository.query.Param;
 public interface TimeVoteStatRepository extends JpaRepository<TimeVoteStat, Long> {
 
   @Modifying
-  @Query("UPDATE TimeVoteStat s SET s.activated = false WHERE s.period.studyId = :studyId")
+  @Query(
+      value =
+          "UPDATE time_vote_stat tvs "
+              + "JOIN time_vote_period p ON p.period_id = tvs.period_id "
+              + "SET tvs.activated = false "
+              + "WHERE p.study_id = :studyId",
+      nativeQuery = true)
   void deactivateAllByPeriod_StudyId(@Param("studyId") Long studyId);
 
   @Modifying

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/TimeVoteMapper.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/TimeVoteMapper.java
@@ -1,8 +1,6 @@
 package grep.neogulcoder.domain.timevote.service;
 
-import grep.neogulcoder.domain.timevote.dto.request.TimeVoteCreateRequest;
 import grep.neogulcoder.domain.timevote.dto.request.TimeVotePeriodCreateRequest;
-import grep.neogulcoder.domain.timevote.dto.request.TimeVoteUpdateRequest;
 import grep.neogulcoder.domain.timevote.TimeVote;
 import grep.neogulcoder.domain.timevote.TimeVotePeriod;
 import java.time.LocalDateTime;
@@ -21,26 +19,6 @@ public class TimeVoteMapper {
         .startDate(request.getStartDate())
         .endDate(adjustedEndDate)
         .build();
-  }
-
-  public List<TimeVote> toEntities(TimeVoteCreateRequest request, TimeVotePeriod period, Long studyMemberId) {
-    return request.getTimeSlots().stream()
-        .map(slot -> TimeVote.builder()
-            .period(period)
-            .studyMemberId(studyMemberId)
-            .timeSlot(slot)
-            .build())
-        .collect(Collectors.toList());
-  }
-
-  public List<TimeVote> toEntities(TimeVoteUpdateRequest request, TimeVotePeriod period, Long studyMemberId) {
-    return request.getTimeSlots().stream()
-        .map(slot -> TimeVote.builder()
-            .period(period)
-            .studyMemberId(studyMemberId)
-            .timeSlot(slot)
-            .build())
-        .collect(Collectors.toList());
   }
 
   public List<TimeVote> toEntities(List<LocalDateTime> timeSlots, TimeVotePeriod period, Long studyMemberId) {

--- a/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteService.java
+++ b/src/main/java/grep/neogulcoder/domain/timevote/service/vote/TimeVoteService.java
@@ -45,13 +45,15 @@ public class TimeVoteService {
   }
 
   public TimeVoteResponse submitVotes(TimeVoteCreateRequest request, Long studyId, Long userId) {
-    TimeVoteContext context = timeVoteValidator.getSubmitContext(studyId, userId, request.getTimeSlots());
-    return executeVoteSubmission(context, request.getTimeSlots());
+    List<LocalDateTime> timeSlots = request.toTimeSlots();
+    TimeVoteContext context = timeVoteValidator.getSubmitContext(studyId, userId, timeSlots);
+    return executeVoteSubmission(context, timeSlots);
   }
 
   public TimeVoteResponse updateVotes(TimeVoteUpdateRequest request, Long studyId, Long userId) {
-    TimeVoteContext context = timeVoteValidator.getUpdateContext(studyId, userId, request.getTimeSlots());
-    return executeVoteSubmission(context, request.getTimeSlots());
+    List<LocalDateTime> timeSlots = request.toTimeSlots();
+    TimeVoteContext context = timeVoteValidator.getUpdateContext(studyId, userId, timeSlots);
+    return executeVoteSubmission(context, timeSlots);
   }
 
   public void deleteAllVotes(Long studyId, Long userId) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,3 +6,12 @@ CREATE UNIQUE INDEX uq_time_vote_stat_period_slot ON time_vote_stat (period_id, 
 -- 사용자 기준 삭제 성능 향상을 위해 추가
 -- getSubmissionStatusList() 쿼리의 성능 최적화 목적
 CREATE INDEX idx_time_vote_period_member ON time_vote (period_id, study_member_id);
+
+-- 스터디별 활성화된 투표 기간 조회/삭제 최적화
+CREATE INDEX idx_time_vote_period_study_activated ON time_vote_period (study_id, activated);
+
+-- 기간/활성화 상태 기준의 투표 데이터 조회/삭제 최적화
+CREATE INDEX idx_time_vote_period_activated ON time_vote (period_id, activated);
+
+-- 기간/활성화 상태 기준의 통계 조회/삭제 최적화
+CREATE INDEX idx_time_vote_stat_period_activated ON time_vote_stat (period_id, activated);


### PR DESCRIPTION
## 📌 과제 설명
- 시간 투표 API 요청/응답을 bitmask 기반으로 전환
- 투표/통계 soft delete 쿼리 및 인덱스 설정/배치 설정 보완

## 👩‍💻 요구 사항과 구현 내용
1. Feat: 시간 투표 API를 비트마스크 포맷으로 전환
* 날짜·bitmask DTO 도입 및 요청 검증/변환 로직 추가
* 응답에 timeMasks 맵 추가, bitmask ↔ LocalDateTime 변환 유틸 구현

2. Chore: 시간 투표 soft delete 쿼리 보완
* UPDATE … JOIN … native 쿼리로 교체하여 Column 'activated' is ambiguous 오류 해결

3. Chore: 시간 투표 인덱스 및 배치 옵션 추가
* time_vote_period, time_vote, time_vote_stat에 study_id/activated 인덱스 추가
* hibernate.jdbc.batch_size=100, order_inserts/order_updates=true 활성화

## ✅ PR 포인트 & 궁금한 점
1. TimeVote API 포맷 변경 및 DB 저장소 분리 (기술적 판단)
* 변경 사항: TimeVote 엔티티의 시간 처리 방식을 시간 단위 비트마스크(Bitmask) 기반으로 전환했습니다.
* 현재 적용 범위: timeMask는 통신(API) 포맷 (DTO)으로만 적용되었으며, DB 저장소 구조는 변경하지 않았습니다.
* DB 저장소 구조 변경을 후속 과제로 분리한 이유: 현재 timeMask는 통신(API) 포맷으로만 전환되었습니다. 이 비트마스크를 DB의 특정 컬럼에 직접 저장할 경우, 향후 MySQL에서 PostgreSQL 등 다른 RDB로 전환할 때 데이터 타입 호환성 및 DB별 비트 연산 함수의 재구현 필요성이 발생합니다. 따라서 이 작업(DB 저장소 구조 변경)은 크로스 플랫폼 재사용성과 데이터 마이그레이션 위험을 고려하여 후속 과제로 분리하였습니다.

2. 배치 처리 성능 최적화 설정 추가 ➡️ **application.properties에 추가 해주세요:)**
* 대량 데이터 처리 시 성능 향상 및 DB 부하 감소를 위해 application.properties에 Hibernate 배치 설정을 추가했습니다. 
이 설정들은 대량의 INSERT/UPDATE/Soft Delete등 작업이 발생할 때 성능을 크게 개선합니다.

`spring.jpa.properties.hibernate.jdbc.batch_size=100
spring.jpa.properties.hibernate.order_inserts=true
spring.jpa.properties.hibernate.order_updates=true`